### PR TITLE
Fix navigation paths for GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+name: Deploy site
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/staticman.yml
+++ b/.github/workflows/staticman.yml
@@ -1,0 +1,31 @@
+name: Booking intake triage
+
+on:
+  pull_request:
+    types: [opened]
+    paths:
+      - 'data/bookings/**'
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'booking';
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            if (!labels.find((item) => item.name === label)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: [label],
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.dist
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.tmp
+.env
+.cache
+dist

--- a/README.md
+++ b/README.md
@@ -26,34 +26,15 @@ I file statici pronti per il deploy sono in `dist/`.
 
 ## Struttura del progetto
 
-```
-├── index.html              # Home e mission
-├── houses.html             # Elenco case
-├── book.html               # Modulo prenotazione
-├── admin.html              # Area riservata (GitHub OAuth)
-├── privacy.html            # Informativa privacy
-├── src/
-│   ├── main.js             # bootstrap Alpine, logica pagine
-│   ├── main.css            # Tailwind + stili custom
-│   ├── i18n.js             # Dizionari IT/EN
-│   ├── services/
-│   │   ├── booking.js      # Invia form → Staticman
-│   │   ├── config.js       # Carica /.well-known/config.json
-│   │   ├── gh.js           # Wrapper API GitHub (Contents, OAuth)
-│   │   └── i18n.js         # Gestione lingua e traduzioni
-│   └── ui/
-│       ├── intersection.js # Effetti fade + lazy load
-│       └── toast.js        # Store notifiche Alpine
-├── data/
-│   ├── houses.json         # Config case (multilingua, gallery)
-│   └── bookings/           # Prenotazioni (una per file JSON)
-├── public/
-│   ├── img/                # Segnaposto per asset generici (demo usa URL remoti)
-│   ├── houses/<slug>/      # Cartella che ospiterà le foto locali caricate dall'admin
-│   └── .well-known/config.json # Config runtime (Staticman + OAuth)
-├── staticman.yml           # Config Staticman (scrive in data/bookings/)
-└── .github/workflows/      # Deploy Pages + triage PR prenotazioni
-```
+La cartella principale contiene i file HTML pubblici (`index`, `houses`, `book`, `admin`, `privacy`) e le risorse di supporto:
+
+- `src/` – entry-point Vite (`main.js`), stili (`main.css`), dizionari (`i18n.js`), servizi riutilizzabili e piccoli componenti Alpine (`ui/`).
+- `data/` – configurazioni di contenuto (`houses.json`) e prenotazioni (`bookings/`).
+- `public/` – asset statici serviti “as-is”; la demo usa URL remoti, ma gli upload dall’admin finiscono in `houses/<slug>/`. Il file `.well-known/config.json` fornisce le impostazioni runtime (Staticman + OAuth).
+- `staticman.yml` – definisce come vengono create le PR con le prenotazioni.
+- `.github/workflows/` – workflow GitHub Actions per build Pages e triage delle PR.
+
+Questa rappresentazione testuale sostituisce l’albero ASCII per ridurre i conflitti durante merge o cherry-pick da altri rami.
 
 ## Dati e immagini
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,131 @@
+# Le case di Città Futura
+
+Sito statico bilingue (IT/EN) per raccontare e gestire le case di accoglienza della comunità di Riace. Il progetto usa [Vite](https://vitejs.dev/), [Tailwind CSS](https://tailwindcss.com/) e [Alpine.js](https://alpinejs.dev/) per un front-end leggero, con dati salvati nel repository (`data/`) e deploy automatico su GitHub Pages.
+
+## Requisiti
+
+- Node.js 20+
+- npm 9+
+
+## Installazione e sviluppo locale
+
+```bash
+npm ci
+npm run dev
+```
+
+Apri `http://localhost:5173` per vedere il sito in sviluppo (hot reload attivo).
+
+Per generare la build di produzione:
+
+```bash
+npm run build
+```
+
+I file statici pronti per il deploy sono in `dist/`.
+
+## Struttura del progetto
+
+```
+├── index.html              # Home e mission
+├── houses.html             # Elenco case
+├── book.html               # Modulo prenotazione
+├── admin.html              # Area riservata (GitHub OAuth)
+├── privacy.html            # Informativa privacy
+├── src/
+│   ├── main.js             # bootstrap Alpine, logica pagine
+│   ├── main.css            # Tailwind + stili custom
+│   ├── i18n.js             # Dizionari IT/EN
+│   ├── services/
+│   │   ├── booking.js      # Invia form → Staticman
+│   │   ├── config.js       # Carica /.well-known/config.json
+│   │   ├── gh.js           # Wrapper API GitHub (Contents, OAuth)
+│   │   └── i18n.js         # Gestione lingua e traduzioni
+│   └── ui/
+│       ├── intersection.js # Effetti fade + lazy load
+│       └── toast.js        # Store notifiche Alpine
+├── data/
+│   ├── houses.json         # Config case (multilingua, gallery)
+│   └── bookings/           # Prenotazioni (una per file JSON)
+├── public/
+│   ├── img/                # Segnaposto per asset generici (demo usa URL remoti)
+│   ├── houses/<slug>/      # Cartella che ospiterà le foto locali caricate dall'admin
+│   └── .well-known/config.json # Config runtime (Staticman + OAuth)
+├── staticman.yml           # Config Staticman (scrive in data/bookings/)
+└── .github/workflows/      # Deploy Pages + triage PR prenotazioni
+```
+
+## Dati e immagini
+
+- `data/houses.json` descrive ogni casa (`id`, nomi tradotti, tag, gallery). Aggiorna questo file via PR o dall’area admin.
+- Nella demo le gallery puntano a foto ospitate su Unsplash per evitare file binari nella repo: quando carichi immagini reali dall’admin verranno salvate in `public/houses/<slug>/`.
+- Crediti demo: Luca Bravo, Cristina Gottardi, Federico Di Dio, Jason Blackeye, Tim Graf, Shifaaz Shamoon – foto pubblicate su Unsplash (Unsplash License).
+- Se aggiungi asset locali (es. loghi o foto ottimizzate) ricordati di rispettare licenze e dimensioni; aggiorna i crediti nel footer con autore e licenza.
+
+## Configurazione Staticman
+
+Il form pubblico (`book.html`) usa [Staticman](https://staticman.net/) per creare automaticamente una Pull Request con la prenotazione (`data/bookings/<timestamp>_<uuid>.json`).
+
+1. Crea/aggiorna `staticman.yml` nel branch `main` (già presente).
+2. Configura un’istanza di Staticman (self-hosted o pubblica) con accesso alla repo.
+3. Aggiorna `/.well-known/config.json` indicando l’endpoint completo (il file vive in `public/.well-known/config.json` e viene pubblicato nella root del sito):
+
+   ```json
+   {
+     "githubClientId": "YOUR_GITHUB_CLIENT_ID",
+     "oauthProxyUrl": "https://your-proxy.example.com/api/exchange",
+     "staticman": {
+       "enabled": true,
+       "endpoint": "https://api.staticman.net/v3/entry/github/<owner>/<repo>/main/bookings"
+     },
+     "bookingIssueFallbackUrl": "https://github.com/<owner>/<repo>/issues/new?template=booking.md"
+   }
+   ```
+
+4. Il campo `bookingIssueFallbackUrl` è mostrato come canale alternativo se Staticman non risponde.
+
+Ogni PR creata da Staticman viene etichettata automaticamente (`booking`) dal workflow `.github/workflows/staticman.yml` per facilitare la moderazione.
+
+## GitHub OAuth per l’area Admin
+
+`admin.html` permette ai maintainer di approvare/rifiutare prenotazioni e gestire le gallery tramite le API Contents. Per motivi di sicurezza sono necessari:
+
+1. **GitHub OAuth App** con redirect URL `https://<org>.github.io/<repo>/admin.html`.
+2. Un **proxy server** (serverless function, Cloudflare Worker, ecc.) che scambia il `code` OAuth con l’`access_token` usando il client secret. L’URL di questo servizio va inserito in `oauthProxyUrl` dentro `/.well-known/config.json`. Non committare mai il secret.
+3. La pagina verifica che l’utente abbia permessi `write`/`maintain`/`admin` sulla repo prima di abilitare le azioni.
+4. Il token è salvato in `sessionStorage` per la durata della sessione e può essere revocato con il pulsante “Disconnetti”.
+
+## Flusso prenotazioni
+
+1. L’utente compila `book.html` (senza login) → POST a Staticman.
+2. Staticman apre una PR con il nuovo JSON in `data/bookings/` (`status: pending`).
+3. Un maintainer revisiona e mergea la PR.
+4. L’area Admin legge i file in `main` e consente di:
+   - cambiare `status` (`pending`, `approved`, `rejected`, `canceled`),
+   - modificare/integrare i dati,
+   - cancellare la prenotazione,
+   - esportare un CSV,
+   - gestire le foto delle case (upload, ordina, imposta cover, elimina).
+
+Ogni modifica usa commit dedicati via GitHub Contents API con messaggi esplicativi.
+
+## Deploy su GitHub Pages
+
+Il workflow `.github/workflows/pages.yml` esegue automaticamente:
+
+1. `npm ci`
+2. `npm run build`
+3. Deploy dell’artefatto `dist/` su GitHub Pages (`gh-pages`).
+
+Assicurati di abilitare “GitHub Pages → Deploy from GitHub Actions” nelle impostazioni della repo.
+
+## Linee guida contributi
+
+- Mantieni la palette e il tono accogliente del progetto.
+- Testa localmente (`npm run build`) prima di proporre modifiche.
+- Le PR con nuovi contenuti devono includere fonti e licenze delle immagini.
+- Per nuovi dizionari aggiungi le chiavi in `src/i18n.js`.
+
+## Licenza
+
+Codice sotto licenza MIT. Le immagini incluse sono rilasciate come CC0 (sostituibili con materiali reali con le relative licenze).

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title data-i18n="admin.page.title">Pannello di amministrazione</title>
+    <meta name="robots" content="noindex" />
+    <script type="module" src="/src/main.js"></script>
+  </head>
+  <body class="bg-sand text-dusk">
+    <div class="flex min-h-screen flex-col">
+      <header class="bg-sand/95 shadow-sm">
+        <nav class="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4">
+          <a href="./" class="flex items-center space-x-2" aria-label="Home">
+            <span class="rounded-full bg-terracotta px-3 py-1 text-xs font-semibold uppercase tracking-widest text-white">CF</span>
+            <span class="font-display text-lg" data-i18n="site.name">Le case di Città Futura</span>
+          </a>
+          <div class="flex items-center space-x-6 text-sm font-medium">
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="index.html" data-i18n="nav.home">Home</a>
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="houses.html" data-i18n="nav.houses">Case</a>
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="book.html" data-i18n="nav.book">Prenota</a>
+            <a class="text-terracotta" href="admin.html" data-i18n="nav.admin">Admin</a>
+            <div x-data="languageSwitcher" class="relative">
+              <button
+                @click="toggle"
+                @keydown.escape="close"
+                class="flex items-center space-x-1 rounded-full border border-terracotta px-3 py-1 text-xs font-semibold text-terracotta focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-terracotta"
+                :aria-expanded="open"
+                type="button"
+              >
+                <span x-text="current.toUpperCase()"></span>
+                <svg class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.186l3.71-3.955a.75.75 0 011.08 1.04l-4.24 4.52a.75.75 0 01-1.08 0l-4.24-4.52a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                </svg>
+              </button>
+              <div x-show="open" x-transition.opacity @click.away="close" class="absolute right-0 mt-2 w-36 rounded-xl bg-white p-2 shadow-lg ring-1 ring-black/5">
+                <button class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-sand" type="button" @click="switchTo('it')">
+                  <span data-i18n="nav.language.it">Italiano</span>
+                </button>
+                <button class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-sand" type="button" @click="switchTo('en')">
+                  <span data-i18n="nav.language.en">English</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </nav>
+      </header>
+
+      <main class="flex-1 bg-gradient-to-b from-white to-sand" x-data="adminApp">
+        <section class="mx-auto max-w-5xl px-6 py-12 space-y-4">
+          <div class="flex items-center justify-between">
+            <div>
+              <h1 class="font-display text-3xl" data-i18n="admin.page.title">Pannello di amministrazione</h1>
+              <p class="mt-2 text-dusk/80" data-i18n="admin.page.subtitle">
+                Gestisci prenotazioni e gallerie. Accesso riservato ai collaboratori della repo GitHub.
+              </p>
+            </div>
+            <template x-if="authenticated">
+              <button class="btn-secondary" type="button" @click="logout" data-i18n="admin.auth.logout">Disconnetti</button>
+            </template>
+          </div>
+
+          <template x-if="error === 'missing-client'">
+            <div class="rounded-xl bg-white p-6 text-sm text-terracotta shadow" role="alert">
+              <p>Imposta il client_id GitHub in /.well-known/config.json.</p>
+            </div>
+          </template>
+          <template x-if="error === 'oauth'">
+            <div class="rounded-xl bg-white p-6 text-sm text-terracotta shadow" role="alert">
+              <p>OAuth non completato. Riprova tra poco.</p>
+            </div>
+          </template>
+          <template x-if="error === 'forbidden'">
+            <div class="rounded-xl bg-white p-6 text-sm text-terracotta shadow" role="alert">
+              <p data-i18n="admin.auth.denied">Non hai i permessi necessari per modificare questo progetto.</p>
+            </div>
+          </template>
+
+          <template x-if="!authenticated && !loading">
+            <div class="rounded-3xl bg-white p-8 shadow">
+              <p class="text-sm text-dusk/80" data-i18n="admin.page.subtitle"></p>
+              <button class="btn-primary mt-4" type="button" @click="login" data-i18n="admin.auth.login">Accedi con GitHub</button>
+            </div>
+          </template>
+
+          <template x-if="checkingPermissions">
+            <p class="text-sm text-dusk/80" data-i18n="admin.auth.checking">Verifica permessi…</p>
+          </template>
+
+          <template x-if="authenticated">
+            <div class="space-y-10">
+              <section class="space-y-4">
+                <div class="flex flex-col gap-4 rounded-3xl bg-white p-6 shadow">
+                  <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div class="flex flex-wrap gap-4">
+                      <div>
+                        <label class="block text-xs uppercase tracking-wide text-dusk/60" for="statusFilter" data-i18n="admin.bookings.table.headers.status">Stato</label>
+                        <select
+                          id="statusFilter"
+                          class="rounded-xl border border-dusk/20 bg-white px-3 py-2 text-sm focus:border-terracotta focus:ring-terracotta"
+                          x-model="filters.status"
+                        >
+                          <option value="all" data-i18n="admin.filters.status.all">Tutti gli stati</option>
+                          <option value="pending" data-i18n="admin.bookings.status.pending">In attesa</option>
+                          <option value="approved" data-i18n="admin.bookings.status.approved">Approvata</option>
+                          <option value="rejected" data-i18n="admin.bookings.status.rejected">Rifiutata</option>
+                          <option value="canceled" data-i18n="admin.bookings.status.canceled">Annullata</option>
+                        </select>
+                      </div>
+                      <div>
+                        <label class="block text-xs uppercase tracking-wide text-dusk/60" for="searchFilter" data-i18n="admin.filters.search">Cerca per nome o email…</label>
+                        <input
+                          id="searchFilter"
+                          type="search"
+                          class="rounded-xl border border-dusk/20 bg-white px-3 py-2 text-sm focus:border-terracotta focus:ring-terracotta"
+                          :placeholder="tKey('admin.filters.search')"
+                          x-model.debounce.300ms="filters.search"
+                        />
+                      </div>
+                    </div>
+                    <div class="flex flex-wrap gap-3">
+                      <button type="button" class="btn-secondary" @click="refreshData" data-i18n="admin.bookings.refresh">Aggiorna elenco</button>
+                      <button type="button" class="btn-secondary" @click="exportCsv" data-i18n="admin.actions.export">Esporta CSV</button>
+                    </div>
+                  </div>
+                  <p class="text-xs text-dusk/60" x-text="lastUpdated ? `${tKey('admin.bookings.lastUpdated')}: ${formatTimestamp(lastUpdated)}` : ''"></p>
+                </div>
+
+                <div class="overflow-hidden rounded-3xl bg-white shadow">
+                  <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-dusk/10 text-left text-sm">
+                      <thead class="bg-sand/60">
+                        <tr>
+                          <th class="px-4 py-3 font-medium" data-i18n="admin.bookings.table.headers.house">Casa</th>
+                          <th class="px-4 py-3 font-medium" data-i18n="admin.bookings.table.headers.name">Ospite</th>
+                          <th class="px-4 py-3 font-medium" data-i18n="admin.bookings.table.headers.dates">Date</th>
+                          <th class="px-4 py-3 font-medium" data-i18n="admin.bookings.table.headers.people">Persone</th>
+                          <th class="px-4 py-3 font-medium" data-i18n="admin.bookings.table.headers.status">Stato</th>
+                          <th class="px-4 py-3 font-medium" data-i18n="admin.bookings.table.headers.actions">Azioni</th>
+                        </tr>
+                      </thead>
+                      <tbody class="divide-y divide-dusk/10" x-show="filteredBookings.length">
+                        <template x-for="booking in filteredBookings" :key="booking.id">
+                          <tr class="hover:bg-sand/30">
+                            <td class="px-4 py-3 font-medium" x-text="houseName(booking.houseId)"></td>
+                            <td class="px-4 py-3">
+                              <div class="font-semibold" x-text="booking.name"></div>
+                              <div class="text-xs text-dusk/60" x-text="booking.email"></div>
+                            </td>
+                            <td class="px-4 py-3 text-sm text-dusk/70" x-text="formatDates(booking)"></td>
+                            <td class="px-4 py-3 text-sm" x-text="peopleLabel(booking)"></td>
+                            <td class="px-4 py-3">
+                              <span class="inline-flex rounded-full bg-sand px-3 py-1 text-xs font-semibold" x-text="statusLabel(booking.status)"></span>
+                            </td>
+                            <td class="px-4 py-3">
+                              <div class="flex flex-wrap gap-2">
+                                <button type="button" class="btn-secondary px-3 py-1" @click="changeStatus(booking, 'approved')" data-i18n="admin.actions.approve">Approva</button>
+                                <button type="button" class="btn-secondary px-3 py-1" @click="changeStatus(booking, 'rejected')" data-i18n="admin.actions.reject">Rifiuta</button>
+                                <button type="button" class="btn-secondary px-3 py-1" @click="changeStatus(booking, 'canceled')" data-i18n="admin.actions.cancel">Annulla</button>
+                                <button type="button" class="btn-secondary px-3 py-1" @click="editBooking(booking)" data-i18n="admin.actions.edit">Modifica</button>
+                                <button type="button" class="btn-secondary px-3 py-1 text-terracotta" @click="deleteBooking(booking)" data-i18n="admin.actions.delete">Elimina</button>
+                              </div>
+                            </td>
+                          </tr>
+                        </template>
+                      </tbody>
+                    </table>
+                  </div>
+                  <template x-if="!filteredBookings.length">
+                    <p class="px-6 py-8 text-center text-sm text-dusk/60" data-i18n="admin.bookings.empty">Nessuna prenotazione registrata.</p>
+                  </template>
+                </div>
+              </section>
+
+              <section class="space-y-4">
+                <div class="flex items-start justify-between">
+                  <div>
+                    <h2 class="font-display text-2xl" data-i18n="admin.images.title">Foto case</h2>
+                    <p class="text-sm text-dusk/70" data-i18n="admin.images.subtitle">
+                      Carica nuove immagini (JPG/PNG, max 2MB). Aggiorna l’ordine trascinando.
+                    </p>
+                  </div>
+                </div>
+                <div class="space-y-6">
+                  <template x-for="house in houses" :key="house.id">
+                    <div class="rounded-3xl bg-white p-6 shadow">
+                      <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                        <div>
+                          <h3 class="text-xl font-semibold" x-text="houseName(house.id)"></h3>
+                          <p class="text-sm text-dusk/60" x-text="house.location"></p>
+                        </div>
+                        <label class="btn-secondary cursor-pointer">
+                          <input type="file" class="hidden" accept="image/*" @change="uploadImage($event, house)" />
+                          <span data-i18n="admin.images.upload">Carica immagine</span>
+                        </label>
+                      </div>
+                      <template x-if="!house.gallery?.length">
+                        <p class="mt-4 text-sm text-dusk/60" data-i18n="admin.images.empty">Nessuna immagine disponibile.</p>
+                      </template>
+                      <div class="mt-4 grid gap-4 md:grid-cols-3" x-show="house.gallery?.length">
+                        <template x-for="image in house.gallery" :key="image">
+                          <figure class="relative overflow-hidden rounded-2xl border border-dusk/10">
+                            <img :src="image" alt="" class="h-40 w-full object-cover" loading="lazy" />
+                            <div class="absolute left-2 top-2 flex items-center gap-2">
+                              <span
+                                class="rounded-full bg-dusk/80 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-white"
+                                x-show="house.cover === image"
+                                data-i18n="admin.images.coverBadge"
+                              >Cover</span>
+                            </div>
+                            <div class="absolute inset-x-0 bottom-2 flex justify-center gap-2">
+                              <button type="button" class="rounded-full bg-white/90 px-2 py-1 text-xs" @click="moveImage(house, image, -1)" data-i18n="admin.images.moveUp">Su</button>
+                              <button type="button" class="rounded-full bg-white/90 px-2 py-1 text-xs" @click="moveImage(house, image, 1)" data-i18n="admin.images.moveDown">Giù</button>
+                            </div>
+                            <div class="absolute inset-x-0 bottom-0 flex justify-between p-2 text-xs">
+                              <button type="button" class="rounded-full bg-white/90 px-3 py-1" @click="setCover(house, image)" data-i18n="admin.images.setCover">Imposta cover</button>
+                              <button type="button" class="rounded-full bg-white/90 px-3 py-1 text-terracotta" @click="removeImage(house, image)" data-i18n="admin.images.remove">Rimuovi</button>
+                            </div>
+                          </figure>
+                        </template>
+                      </div>
+                    </div>
+                  </template>
+                </div>
+              </section>
+            </div>
+          </template>
+        </section>
+
+        <div
+          class="fixed inset-0 z-50 flex items-center justify-center bg-dusk/40 px-4"
+          x-show="modalOpen"
+          x-transition.opacity
+          role="dialog"
+          aria-modal="true"
+        >
+          <div class="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-3xl bg-white p-6 shadow-xl" x-show="modalOpen" x-transition>
+            <h2 class="text-xl font-semibold mb-4" data-i18n="admin.actions.edit">Modifica</h2>
+            <form class="space-y-4" @submit.prevent="saveBooking">
+              <div class="grid gap-4 md:grid-cols-2">
+                <div>
+                  <label class="text-xs uppercase tracking-wide text-dusk/60" for="edit-name">Nome</label>
+                  <input id="edit-name" type="text" class="mt-1 w-full rounded-xl border border-dusk/20 px-3 py-2" x-model="editableBooking.name" required />
+                </div>
+                <div>
+                  <label class="text-xs uppercase tracking-wide text-dusk/60" for="edit-email">Email</label>
+                  <input id="edit-email" type="email" class="mt-1 w-full rounded-xl border border-dusk/20 px-3 py-2" x-model="editableBooking.email" required />
+                </div>
+                <div>
+                  <label class="text-xs uppercase tracking-wide text-dusk/60" for="edit-phone">Telefono</label>
+                  <input id="edit-phone" type="text" class="mt-1 w-full rounded-xl border border-dusk/20 px-3 py-2" x-model="editableBooking.phone" />
+                </div>
+                <div>
+                  <label class="text-xs uppercase tracking-wide text-dusk/60" for="edit-status">Stato</label>
+                  <select id="edit-status" class="mt-1 w-full rounded-xl border border-dusk/20 px-3 py-2" x-model="editableBooking.status">
+                    <option value="pending" data-i18n="admin.bookings.status.pending">In attesa</option>
+                    <option value="approved" data-i18n="admin.bookings.status.approved">Approvata</option>
+                    <option value="rejected" data-i18n="admin.bookings.status.rejected">Rifiutata</option>
+                    <option value="canceled" data-i18n="admin.bookings.status.canceled">Annullata</option>
+                  </select>
+                </div>
+                <div>
+                  <label class="text-xs uppercase tracking-wide text-dusk/60" for="edit-checkin">Arrivo</label>
+                  <input id="edit-checkin" type="date" class="mt-1 w-full rounded-xl border border-dusk/20 px-3 py-2" x-model="editableBooking.checkin" />
+                </div>
+                <div>
+                  <label class="text-xs uppercase tracking-wide text-dusk/60" for="edit-checkout">Partenza</label>
+                  <input id="edit-checkout" type="date" class="mt-1 w-full rounded-xl border border-dusk/20 px-3 py-2" x-model="editableBooking.checkout" />
+                </div>
+              </div>
+              <div>
+                <label class="text-xs uppercase tracking-wide text-dusk/60" for="edit-people">Persone</label>
+                <input id="edit-people" type="number" min="1" class="mt-1 w-full rounded-xl border border-dusk/20 px-3 py-2" x-model.number="editableBooking.people" />
+              </div>
+              <div>
+                <label class="text-xs uppercase tracking-wide text-dusk/60" for="edit-notes">Note</label>
+                <textarea id="edit-notes" rows="4" class="mt-1 w-full rounded-xl border border-dusk/20 px-3 py-2" x-model="editableBooking.notes"></textarea>
+              </div>
+              <div class="flex justify-end gap-3">
+                <button type="button" class="btn-secondary" @click="closeModal" data-i18n="admin.actions.close">Chiudi</button>
+                <button type="submit" class="btn-primary" data-i18n="admin.actions.save">Salva</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+
+      <footer class="bg-dusk text-sand">
+        <div class="mx-auto max-w-5xl space-y-4 px-6 py-10 text-sm">
+          <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <p data-i18n="footer.rights">© Città Futura. Tutti i diritti riservati.</p>
+            <p data-i18n="footer.credit.photos">
+              Foto: Luca Bravo, Cristina Gottardi, Federico Di Dio, Jason Blackeye, Tim Graf, Shifaaz Shamoon via Unsplash (licenza Unsplash).
+            </p>
+          </div>
+          <p data-i18n="footer.credit.contact">Per collaborare: cittafutura@example.org</p>
+        </div>
+      </footer>
+    </div>
+
+    <div class="pointer-events-none fixed inset-0 z-[60] flex flex-col items-end space-y-2 p-4" x-data>
+      <template x-for="toast in $store.toast.items" :key="toast.id">
+        <div
+          class="pointer-events-auto w-full max-w-xs rounded-2xl bg-white p-4 shadow-lg ring-1 ring-black/5"
+          :class="{ 'border-l-4 border-terracotta': toast.type === 'error', 'border-l-4 border-olive': toast.type === 'success' }"
+        >
+          <p class="text-sm text-dusk" x-text="toast.message"></p>
+        </div>
+      </template>
+    </div>
+  </body>
+</html>

--- a/admin.html
+++ b/admin.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title data-i18n="admin.page.title">Pannello di amministrazione</title>
     <meta name="robots" content="noindex" />
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   </head>
   <body class="bg-sand text-dusk">
     <div class="flex min-h-screen flex-col">

--- a/book.html
+++ b/book.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title data-i18n="book.page.title">Richiedi una prenotazione</title>
     <meta name="description" content="Compila il modulo per richiedere un soggiorno solidale a Riace." />
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   </head>
   <body class="bg-sand text-dusk">
     <div class="flex min-h-screen flex-col">

--- a/book.html
+++ b/book.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title data-i18n="book.page.title">Richiedi una prenotazione</title>
+    <meta name="description" content="Compila il modulo per richiedere un soggiorno solidale a Riace." />
+    <script type="module" src="/src/main.js"></script>
+  </head>
+  <body class="bg-sand text-dusk">
+    <div class="flex min-h-screen flex-col">
+      <header class="bg-sand/95 shadow-sm">
+        <nav class="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4">
+          <a href="./" class="flex items-center space-x-2" aria-label="Home">
+            <span class="rounded-full bg-terracotta px-3 py-1 text-xs font-semibold uppercase tracking-widest text-white">CF</span>
+            <span class="font-display text-lg" data-i18n="site.name">Le case di Città Futura</span>
+          </a>
+          <div class="flex items-center space-x-6 text-sm font-medium">
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="index.html" data-i18n="nav.home">Home</a>
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="houses.html" data-i18n="nav.houses">Case</a>
+            <a class="text-terracotta" href="book.html" data-i18n="nav.book">Prenota</a>
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="admin.html" data-i18n="nav.admin">Admin</a>
+            <div x-data="languageSwitcher" class="relative">
+              <button
+                @click="toggle"
+                @keydown.escape="close"
+                class="flex items-center space-x-1 rounded-full border border-terracotta px-3 py-1 text-xs font-semibold text-terracotta focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-terracotta"
+                :aria-expanded="open"
+                type="button"
+              >
+                <span x-text="current.toUpperCase()"></span>
+                <svg class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.186l3.71-3.955a.75.75 0 011.08 1.04l-4.24 4.52a.75.75 0 01-1.08 0l-4.24-4.52a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                </svg>
+              </button>
+              <div x-show="open" x-transition.opacity @click.away="close" class="absolute right-0 mt-2 w-36 rounded-xl bg-white p-2 shadow-lg ring-1 ring-black/5">
+                <button class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-sand" type="button" @click="switchTo('it')">
+                  <span data-i18n="nav.language.it">Italiano</span>
+                </button>
+                <button class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-sand" type="button" @click="switchTo('en')">
+                  <span data-i18n="nav.language.en">English</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </nav>
+      </header>
+
+      <main class="flex-1 bg-gradient-to-b from-white to-sand">
+        <section class="mx-auto max-w-3xl px-6 py-12 text-center space-y-4">
+          <h1 class="font-display text-4xl" data-i18n="book.page.title">Richiedi una prenotazione</h1>
+          <p class="text-lg text-dusk/80" data-i18n="book.page.subtitle">
+            Compila il form: il team di Città Futura approverà la richiesta appena possibile.
+          </p>
+        </section>
+
+        <section class="mx-auto w-full max-w-4xl px-6 pb-16" x-data="bookingForm">
+          <form
+            class="card space-y-6 p-8"
+            @submit.prevent="submit"
+            x-ref="form"
+            novalidate
+          >
+            <div class="grid gap-6 md:grid-cols-2">
+              <div class="flex flex-col space-y-2">
+                <label class="text-sm font-semibold" for="house" data-i18n="book.form.house">Casa</label>
+                <select
+                  id="house"
+                  name="houseId"
+                  class="rounded-xl border border-dusk/20 bg-white px-3 py-2 focus:border-terracotta focus:ring-terracotta"
+                  required
+                  x-ref="houseSelect"
+                >
+                  <option value="" data-i18n="book.form.selectHouse">Scegli una casa</option>
+                  <template x-for="house in houses" :key="house.id">
+                    <option :value="house.id" x-text="house.name?.[lang] ?? house.name?.it"></option>
+                  </template>
+                </select>
+              </div>
+              <div class="flex flex-col space-y-2">
+                <label class="text-sm font-semibold" for="name" data-i18n="book.form.name">Nome e cognome</label>
+                <input
+                  type="text"
+                  id="name"
+                  name="name"
+                  class="rounded-xl border border-dusk/20 bg-white px-3 py-2 focus:border-terracotta focus:ring-terracotta"
+                  required
+                  autocomplete="name"
+                />
+              </div>
+              <div class="flex flex-col space-y-2">
+                <label class="text-sm font-semibold" for="email" data-i18n="book.form.email">Email</label>
+                <input
+                  type="email"
+                  id="email"
+                  name="email"
+                  class="rounded-xl border border-dusk/20 bg-white px-3 py-2 focus:border-terracotta focus:ring-terracotta"
+                  required
+                  autocomplete="email"
+                />
+              </div>
+              <div class="flex flex-col space-y-2">
+                <label class="text-sm font-semibold" for="phone" data-i18n="book.form.phone">Telefono</label>
+                <input
+                  type="tel"
+                  id="phone"
+                  name="phone"
+                  class="rounded-xl border border-dusk/20 bg-white px-3 py-2 focus:border-terracotta focus:ring-terracotta"
+                  required
+                  autocomplete="tel"
+                />
+              </div>
+              <div class="flex flex-col space-y-2">
+                <label class="text-sm font-semibold" for="checkin" data-i18n="book.form.checkin">Arrivo</label>
+                <input
+                  type="date"
+                  id="checkin"
+                  name="checkin"
+                  class="rounded-xl border border-dusk/20 bg-white px-3 py-2 focus:border-terracotta focus:ring-terracotta"
+                  required
+                />
+              </div>
+              <div class="flex flex-col space-y-2">
+                <label class="text-sm font-semibold" for="checkout" data-i18n="book.form.checkout">Partenza</label>
+                <input
+                  type="date"
+                  id="checkout"
+                  name="checkout"
+                  class="rounded-xl border border-dusk/20 bg-white px-3 py-2 focus:border-terracotta focus:ring-terracotta"
+                  required
+                />
+              </div>
+            </div>
+
+            <div class="grid gap-6 md:grid-cols-2">
+              <div class="flex flex-col space-y-2">
+                <label class="text-sm font-semibold" for="people" data-i18n="book.form.people">Persone</label>
+                <input
+                  type="number"
+                  id="people"
+                  name="people"
+                  min="1"
+                  value="1"
+                  class="rounded-xl border border-dusk/20 bg-white px-3 py-2 focus:border-terracotta focus:ring-terracotta"
+                  required
+                />
+              </div>
+              <div class="flex flex-col space-y-2">
+                <label class="text-sm font-semibold" for="notes" data-i18n="book.form.notes">Note</label>
+                <textarea
+                  id="notes"
+                  name="notes"
+                  rows="3"
+                  class="rounded-xl border border-dusk/20 bg-white px-3 py-2 focus:border-terracotta focus:ring-terracotta"
+                  data-i18n-attr="placeholder:book.form.notes.placeholder"
+                  placeholder="Allergie, richieste specifiche…"
+                ></textarea>
+              </div>
+            </div>
+
+            <div class="hidden">
+              <label for="website" data-i18n="book.form.honeypot">Lascia questo campo vuoto</label>
+              <input type="text" name="website" id="website" tabindex="-1" autocomplete="off" />
+            </div>
+
+            <div class="flex items-start space-x-3">
+              <input type="checkbox" id="privacy" name="privacy" class="mt-1 rounded border-dusk/30 text-terracotta focus:ring-terracotta" required />
+              <label for="privacy" class="text-sm text-dusk/80">
+                <span data-i18n="book.form.privacy">Ho letto e accetto l'informativa privacy</span>
+                <a href="privacy.html" class="ml-1 underline" data-i18n="book.form.privacy.link">Informativa privacy</a>
+              </label>
+            </div>
+
+            <div class="flex flex-col gap-4">
+              <button
+                type="submit"
+                class="btn-primary self-start"
+                :disabled="status === 'loading'"
+                x-text="status === 'loading' ? tKey('book.form.submitting') : tKey('book.form.submit')"
+              >
+                Invia richiesta
+              </button>
+              <p
+                x-show="message"
+                x-text="message"
+                class="text-sm"
+                :class="status === 'success' ? 'text-olive' : 'text-terracotta'"
+                role="status"
+                aria-live="polite"
+              ></p>
+              <p class="text-xs text-dusk/60">
+                <span data-i18n="book.form.altChannel">In alternativa puoi aprire una richiesta su GitHub.</span>
+                <a :href="fallbackLink" class="ml-1 underline" data-i18n="book.form.openIssue">Apri richiesta su GitHub</a>
+              </p>
+            </div>
+          </form>
+        </section>
+      </main>
+
+      <footer class="bg-dusk text-sand">
+        <div class="mx-auto max-w-5xl space-y-4 px-6 py-10 text-sm">
+          <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <p data-i18n="footer.rights">© Città Futura. Tutti i diritti riservati.</p>
+            <p data-i18n="footer.credit.photos">
+              Foto: Luca Bravo, Cristina Gottardi, Federico Di Dio, Jason Blackeye, Tim Graf, Shifaaz Shamoon via Unsplash (licenza Unsplash).
+            </p>
+          </div>
+          <p data-i18n="footer.credit.contact">Per collaborare: cittafutura@example.org</p>
+        </div>
+      </footer>
+    </div>
+
+    <div class="pointer-events-none fixed inset-0 z-[60] flex flex-col items-end space-y-2 p-4" x-data>
+      <template x-for="toast in $store.toast.items" :key="toast.id">
+        <div
+          class="pointer-events-auto w-full max-w-xs rounded-2xl bg-white p-4 shadow-lg ring-1 ring-black/5"
+          :class="{ 'border-l-4 border-terracotta': toast.type === 'error', 'border-l-4 border-olive': toast.type === 'success' }"
+        >
+          <p class="text-sm text-dusk" x-text="toast.message"></p>
+        </div>
+      </template>
+    </div>
+  </body>
+</html>

--- a/data/bookings/README.md
+++ b/data/bookings/README.md
@@ -1,0 +1,4 @@
+# Prenotazioni
+
+Questa cartella conterrà i file JSON generati da Staticman per ogni richiesta di prenotazione.
+Lasciare la directory tracciata permette al workflow di creare nuove proposte di modifica senza errori.

--- a/data/houses.json
+++ b/data/houses.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "casa-del-porto",
+    "name": {
+      "it": "Casa del Porto",
+      "en": "Harbour Home"
+    },
+    "summary": {
+      "it": "Appartamento luminoso con terrazzo vista mare, ideale per famiglie e gruppi piccoli.",
+      "en": "Bright apartment with a sea-view terrace, perfect for families and small groups."
+    },
+    "location": "Riace Marina (RC)",
+    "cover": "https://images.unsplash.com/photo-1493558103817-58b2924bce98?auto=format&fit=crop&w=1600&q=80",
+    "gallery": [
+      "https://images.unsplash.com/photo-1493558103817-58b2924bce98?auto=format&fit=crop&w=1600&q=80",
+      "https://images.unsplash.com/photo-1505761671935-60b3a7427bad?auto=format&fit=crop&w=1600&q=80",
+      "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1600&q=80"
+    ],
+    "tags": ["mare", "famiglie", "terrazza"],
+    "active": true
+  },
+  {
+    "id": "casa-della-piazza",
+    "name": {
+      "it": "Casa della Piazza",
+      "en": "Piazza House"
+    },
+    "summary": {
+      "it": "Nel cuore del borgo storico di Riace, a pochi passi dai laboratori artigiani.",
+      "en": "In the heart of the historic village, a few steps from artisan workshops."
+    },
+    "location": "Riace Borgo (RC)",
+    "cover": "https://images.unsplash.com/photo-1470123186770-69bf0c1f0e6f?auto=format&fit=crop&w=1600&q=80",
+    "gallery": [
+      "https://images.unsplash.com/photo-1470123186770-69bf0c1f0e6f?auto=format&fit=crop&w=1600&q=80",
+      "https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1600&q=80",
+      "https://images.unsplash.com/photo-1472214103451-9374bd1c798e?auto=format&fit=crop&w=1600&q=80"
+    ],
+    "tags": ["borgo", "coppie", "botteghe"],
+    "active": true
+  },
+  {
+    "id": "casa-dei-gelsi",
+    "name": {
+      "it": "Casa dei Gelsi",
+      "en": "Mulberry House"
+    },
+    "summary": {
+      "it": "Casetta indipendente immersa nel verde con giardino ombreggiato e spazio per laboratori.",
+      "en": "Independent house surrounded by greenery with a shaded garden and space for workshops."
+    },
+    "location": "Campagna di Riace (RC)",
+    "cover": "https://images.unsplash.com/photo-1467269204594-9661b134dd2b?auto=format&fit=crop&w=1600&q=80",
+    "gallery": [
+      "https://images.unsplash.com/photo-1467269204594-9661b134dd2b?auto=format&fit=crop&w=1600&q=80",
+      "https://images.unsplash.com/photo-1470123186770-69bf0c1f0e6f?auto=format&fit=crop&w=1600&q=80",
+      "https://images.unsplash.com/photo-1505761671935-60b3a7427bad?auto=format&fit=crop&w=1600&q=80"
+    ],
+    "tags": ["giardino", "gruppi", "laboratori"],
+    "active": true
+  }
+]

--- a/houses.html
+++ b/houses.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title data-i18n="houses.page.title">Case disponibili</title>
     <meta name="description" content="Elenco delle case accoglienti di Città Futura a Riace." />
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   </head>
   <body class="bg-sand text-dusk">
     <div class="flex min-h-screen flex-col">

--- a/houses.html
+++ b/houses.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title data-i18n="houses.page.title">Case disponibili</title>
+    <meta name="description" content="Elenco delle case accoglienti di Città Futura a Riace." />
+    <script type="module" src="/src/main.js"></script>
+  </head>
+  <body class="bg-sand text-dusk">
+    <div class="flex min-h-screen flex-col">
+      <header class="bg-sand/95 shadow-sm">
+        <nav class="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4">
+          <a href="./" class="flex items-center space-x-2" aria-label="Home">
+            <span class="rounded-full bg-terracotta px-3 py-1 text-xs font-semibold uppercase tracking-widest text-white">CF</span>
+            <span class="font-display text-lg" data-i18n="site.name">Le case di Città Futura</span>
+          </a>
+          <div class="flex items-center space-x-6 text-sm font-medium">
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="index.html" data-i18n="nav.home">Home</a>
+            <a class="text-terracotta" href="houses.html" data-i18n="nav.houses">Case</a>
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="book.html" data-i18n="nav.book">Prenota</a>
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="admin.html" data-i18n="nav.admin">Admin</a>
+            <div x-data="languageSwitcher" class="relative">
+              <button
+                @click="toggle"
+                @keydown.escape="close"
+                class="flex items-center space-x-1 rounded-full border border-terracotta px-3 py-1 text-xs font-semibold text-terracotta focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-terracotta"
+                :aria-expanded="open"
+                type="button"
+              >
+                <span x-text="current.toUpperCase()"></span>
+                <svg class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.186l3.71-3.955a.75.75 0 011.08 1.04l-4.24 4.52a.75.75 0 01-1.08 0l-4.24-4.52a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                </svg>
+              </button>
+              <div x-show="open" x-transition.opacity @click.away="close" class="absolute right-0 mt-2 w-36 rounded-xl bg-white p-2 shadow-lg ring-1 ring-black/5">
+                <button class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-sand" type="button" @click="switchTo('it')">
+                  <span data-i18n="nav.language.it">Italiano</span>
+                </button>
+                <button class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-sand" type="button" @click="switchTo('en')">
+                  <span data-i18n="nav.language.en">English</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </nav>
+      </header>
+
+      <main class="flex-1">
+        <section class="bg-white py-16 shadow-sm">
+          <div class="mx-auto max-w-4xl px-6 text-center space-y-4">
+            <h1 class="font-display text-4xl" data-i18n="houses.page.title">Case disponibili</h1>
+            <p class="text-lg text-dusk/80" data-i18n="houses.page.subtitle">
+              Spazi accoglienti curati dalla comunità di Riace. Contattaci se hai esigenze specifiche.
+            </p>
+          </div>
+        </section>
+
+        <section class="mx-auto w-full max-w-6xl px-6 py-16" x-data="housesList">
+          <template x-if="loading">
+            <p class="text-center text-sm text-dusk/60">Loading…</p>
+          </template>
+          <template x-if="!loading && !houses.length">
+            <p class="text-center text-sm text-dusk/60" data-i18n="houses.page.empty">Nessuna casa disponibile al momento.</p>
+          </template>
+          <div class="grid gap-8 md:grid-cols-2" data-animate="fade">
+            <template x-for="house in houses" :key="house.id">
+              <article class="card flex h-full flex-col overflow-hidden">
+                <img :src="house.cover" :alt="nameFor(house)" class="h-56 w-full object-cover lazy-image" loading="lazy" />
+                <div class="flex flex-1 flex-col space-y-4 p-6">
+                  <div class="space-y-2">
+                    <h2 class="text-2xl font-semibold" x-text="nameFor(house)"></h2>
+                    <p class="text-sm text-dusk/70" x-text="summaryFor(house)"></p>
+                    <p class="text-xs uppercase tracking-wide text-dusk/60" x-text="house.location"></p>
+                  </div>
+                  <div class="flex flex-wrap gap-2">
+                    <template x-for="tag in house.tags" :key="tag">
+                      <span class="tag" x-text="tag"></span>
+                    </template>
+                  </div>
+                  <div class="mt-auto flex items-center justify-between">
+                    <a :href="bookUrl(house)" class="btn-primary" data-i18n="houses.card.book">Prenota</a>
+                    <span class="text-xs text-dusk/50" x-text="house.active ? '' : 'Offline'"></span>
+                  </div>
+                </div>
+              </article>
+            </template>
+          </div>
+        </section>
+      </main>
+
+      <footer class="bg-dusk text-sand">
+        <div class="mx-auto max-w-5xl space-y-4 px-6 py-10 text-sm">
+          <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <p data-i18n="footer.rights">© Città Futura. Tutti i diritti riservati.</p>
+            <p data-i18n="footer.credit.photos">
+              Foto: Luca Bravo, Cristina Gottardi, Federico Di Dio, Jason Blackeye, Tim Graf, Shifaaz Shamoon via Unsplash (licenza Unsplash).
+            </p>
+          </div>
+          <p data-i18n="footer.credit.contact">Per collaborare: cittafutura@example.org</p>
+        </div>
+      </footer>
+    </div>
+
+    <div class="pointer-events-none fixed inset-0 z-[60] flex flex-col items-end space-y-2 p-4" x-data>
+      <template x-for="toast in $store.toast.items" :key="toast.id">
+        <div
+          class="pointer-events-auto w-full max-w-xs rounded-2xl bg-white p-4 shadow-lg ring-1 ring-black/5"
+          :class="{ 'border-l-4 border-terracotta': toast.type === 'error', 'border-l-4 border-olive': toast.type === 'success' }"
+        >
+          <p class="text-sm text-dusk" x-text="toast.message"></p>
+        </div>
+      </template>
+    </div>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title data-i18n="site.name">Le case di Città Futura</title>
+    <meta
+      name="description"
+      content="Ospitalità solidale a Riace: scopri le case della comunità di Città Futura."
+    />
+    <link
+      rel="icon"
+      type="image/jpeg"
+      href="https://images.unsplash.com/photo-1472214103451-9374bd1c798e?auto=format&amp;fit=crop&amp;w=64&amp;q=60"
+    />
+    <link
+      rel="preload"
+      as="image"
+      href="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&amp;fit=crop&amp;w=2000&amp;q=80"
+    />
+    <script type="module" src="/src/main.js"></script>
+  </head>
+  <body class="bg-sand text-dusk">
+    <div class="flex min-h-screen flex-col">
+      <header class="sticky top-0 z-50 bg-sand/90 backdrop-blur">
+        <nav class="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4">
+          <a href="./" class="flex items-center space-x-2" aria-label="Home">
+            <span class="rounded-full bg-terracotta px-3 py-1 text-xs font-semibold uppercase tracking-widest text-white">
+              CF
+            </span>
+            <span class="font-display text-lg" data-i18n="site.name">Le case di Città Futura</span>
+          </a>
+          <div class="flex items-center space-x-6 text-sm font-medium">
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="index.html" data-i18n="nav.home">Home</a>
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="houses.html" data-i18n="nav.houses">Case</a>
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="book.html" data-i18n="nav.book">Prenota</a>
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="admin.html" data-i18n="nav.admin">Admin</a>
+            <div x-data="languageSwitcher" class="relative">
+              <button
+                @click="toggle"
+                @keydown.escape="close"
+                class="flex items-center space-x-1 rounded-full border border-terracotta px-3 py-1 text-xs font-semibold text-terracotta focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-terracotta"
+                :aria-expanded="open"
+                type="button"
+              >
+                <span x-text="current.toUpperCase()"></span>
+                <svg class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.186l3.71-3.955a.75.75 0 011.08 1.04l-4.24 4.52a.75.75 0 01-1.08 0l-4.24-4.52a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                </svg>
+              </button>
+              <div
+                x-show="open"
+                x-transition.opacity
+                @click.away="close"
+                class="absolute right-0 mt-2 w-36 rounded-xl bg-white p-2 shadow-lg ring-1 ring-black/5"
+              >
+                <button
+                  class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-sand"
+                  type="button"
+                  @click="switchTo('it')"
+                >
+                  <span data-i18n="nav.language.it">Italiano</span>
+                </button>
+                <button
+                  class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-sand"
+                  type="button"
+                  @click="switchTo('en')"
+                >
+                  <span data-i18n="nav.language.en">English</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </nav>
+      </header>
+
+      <main class="flex-1">
+        <section class="relative isolate overflow-hidden">
+          <img
+            src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&amp;fit=crop&amp;w=2000&amp;q=80"
+            alt="Scogliera colorata sul mare di Riomaggiore al tramonto"
+            class="h-[500px] w-full object-cover object-center"
+            loading="eager"
+          />
+          <div class="absolute inset-0 bg-gradient-to-r from-dusk/80 to-dusk/20"></div>
+          <div class="absolute inset-0 flex items-center">
+            <div class="mx-auto w-full max-w-5xl px-6">
+              <div class="max-w-xl space-y-6 text-white" data-animate="fade">
+                <p class="inline-flex rounded-full bg-white/20 px-3 py-1 text-xs uppercase tracking-[0.3em] text-sand">
+                  Città Futura
+                </p>
+                <h1 class="font-display text-4xl font-semibold" data-i18n="hero.title">
+                  Ospitalità solidale nel cuore di Riace
+                </h1>
+                <p class="text-lg" data-i18n="hero.subtitle">
+                  Accogliamo viaggiatori e nuove comunità in case condivise, per vivere la Calabria con lentezza e rispetto.
+                </p>
+                <div class="flex flex-wrap gap-4">
+                  <a href="houses.html" class="btn-primary" data-i18n="hero.cta.houses">Vedi case</a>
+                  <a href="book.html" class="btn-secondary" data-i18n="hero.cta.book">Prenota</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="mx-auto flex max-w-5xl flex-col gap-12 px-6 py-16">
+          <div class="max-w-3xl space-y-4" data-animate="fade">
+            <h2 class="font-display text-3xl" data-i18n="mission.title">Ospitalità che crea comunità</h2>
+            <p class="text-lg" data-i18n="mission.text">
+              Città Futura nasce dall’esperienza di accoglienza di Riace. Le nostre case sono aperte a chi cerca un soggiorno autentico, etico e vicino alle persone che abitano questi luoghi.
+            </p>
+          </div>
+          <dl class="grid gap-8 md:grid-cols-3" data-animate="fade">
+            <div class="card space-y-3 p-6">
+              <dt class="font-semibold" data-i18n="mission.values.community.title">Comunità</dt>
+              <dd class="text-sm text-dusk/80" data-i18n="mission.values.community.text">
+                Ogni soggiorno sostiene la rete di vicinato, i laboratori artigiani e i progetti sociali locali.
+              </dd>
+            </div>
+            <div class="card space-y-3 p-6">
+              <dt class="font-semibold" data-i18n="mission.values.inclusion.title">Inclusione</dt>
+              <dd class="text-sm text-dusk/80" data-i18n="mission.values.inclusion.text">
+                Le case sono gestite insieme a famiglie del territorio e persone rifugiate, con attenzione ai bisogni di tutte e tutti.
+              </dd>
+            </div>
+            <div class="card space-y-3 p-6">
+              <dt class="font-semibold" data-i18n="mission.values.environment.title">Territorio</dt>
+              <dd class="text-sm text-dusk/80" data-i18n="mission.values.environment.text">
+                Promuoviamo un turismo lento: consigli su come muoversi senza auto e scoprire le bellezze dello Ionio.
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <section class="bg-white py-16">
+          <div class="mx-auto max-w-5xl px-6">
+            <div class="flex flex-col gap-6 md:flex-row md:items-end md:justify-between" data-animate="fade">
+              <div>
+                <h2 class="font-display text-3xl" data-i18n="houses.preview.title">Le nostre case</h2>
+                <p class="mt-2 max-w-2xl text-dusk/80" data-i18n="houses.preview.subtitle">
+                  Ogni appartamento racconta una storia di accoglienza condivisa. Prenota ora per vivere l’esperienza.
+                </p>
+              </div>
+              <a href="houses.html" class="btn-secondary self-start" data-i18n="houses.preview.cta">Tutte le case</a>
+            </div>
+            <div class="mt-10 grid gap-6 md:grid-cols-3" x-data="housesList" data-animate="fade">
+              <template x-if="loading">
+                <p class="col-span-3 text-center text-sm text-dusk/60">Loading…</p>
+              </template>
+              <template x-if="!loading && !houses.length">
+                <p class="col-span-3 text-center text-sm text-dusk/60" data-i18n="houses.page.empty">
+                  Nessuna casa disponibile al momento.
+                </p>
+              </template>
+              <template x-for="house in houses.slice(0,3)" :key="house.id">
+                <article class="card flex h-full flex-col overflow-hidden">
+                  <img
+                    class="h-48 w-full object-cover lazy-image"
+                    :src="house.cover"
+                    :alt="nameFor(house)"
+                    loading="lazy"
+                  />
+                  <div class="flex flex-1 flex-col space-y-4 p-6">
+                    <div>
+                      <h3 class="text-xl font-semibold" x-text="nameFor(house)"></h3>
+                      <p class="mt-2 text-sm text-dusk/70" x-text="summaryFor(house)"></p>
+                    </div>
+                    <div class="flex flex-wrap gap-2">
+                      <template x-for="tag in house.tags" :key="tag">
+                        <span class="tag" x-text="tag"></span>
+                      </template>
+                    </div>
+                    <a
+                      class="btn-secondary mt-auto self-start"
+                      :href="bookUrl(house)"
+                      data-i18n="houses.card.book"
+                    >
+                      Prenota
+                    </a>
+                  </div>
+                </article>
+              </template>
+            </div>
+          </div>
+        </section>
+
+        <section class="bg-gradient-to-b from-sand to-white py-16">
+          <div class="mx-auto max-w-5xl px-6">
+            <div class="space-y-3" data-animate="fade">
+              <h2 class="font-display text-3xl" data-i18n="gallery.title">Scopri Riace</h2>
+              <p class="text-dusk/80" data-i18n="gallery.caption">
+                Paesaggi, colori e comunità che rendono unico questo luogo.
+              </p>
+            </div>
+            <div class="mt-8 grid gap-6 md:grid-cols-3">
+              <figure class="overflow-hidden rounded-3xl shadow-lg" data-animate="fade">
+                <img
+                  src="https://images.unsplash.com/photo-1472214103451-9374bd1c798e?auto=format&amp;fit=crop&amp;w=1200&amp;q=80"
+                  alt="Case colorate affacciate sul porto di Riomaggiore"
+                  class="h-64 w-full object-cover lazy-image"
+                  loading="lazy"
+                />
+              </figure>
+              <figure class="overflow-hidden rounded-3xl shadow-lg" data-animate="fade">
+                <img
+                  src="https://images.unsplash.com/photo-1470123186770-69bf0c1f0e6f?auto=format&amp;fit=crop&amp;w=1200&amp;q=80"
+                  alt="Vicoli in pietra immersi nel borgo storico di Riace"
+                  class="h-64 w-full object-cover lazy-image"
+                  loading="lazy"
+                />
+              </figure>
+              <figure class="overflow-hidden rounded-3xl shadow-lg" data-animate="fade">
+                <img
+                  src="https://images.unsplash.com/photo-1467269204594-9661b134dd2b?auto=format&amp;fit=crop&amp;w=1200&amp;q=80"
+                  alt="Colline verdi e campi assolati della costa ionica"
+                  class="h-64 w-full object-cover lazy-image"
+                  loading="lazy"
+                />
+              </figure>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="bg-dusk text-sand">
+        <div class="mx-auto max-w-5xl space-y-4 px-6 py-10 text-sm">
+          <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <p data-i18n="footer.rights">© Città Futura. Tutti i diritti riservati.</p>
+            <p data-i18n="footer.credit.photos">
+              Foto: Luca Bravo, Cristina Gottardi, Federico Di Dio, Jason Blackeye, Tim Graf, Shifaaz Shamoon via Unsplash (licenza Unsplash).
+            </p>
+          </div>
+          <p data-i18n="footer.credit.contact">Per collaborare: cittafutura@example.org</p>
+        </div>
+      </footer>
+    </div>
+
+    <div
+      class="pointer-events-none fixed inset-0 z-[60] flex flex-col items-end space-y-2 p-4"
+      x-data
+      x-init="() => {}"
+    >
+      <template x-for="toast in $store.toast.items" :key="toast.id">
+        <div
+          class="pointer-events-auto w-full max-w-xs rounded-2xl bg-white p-4 shadow-lg ring-1 ring-black/5"
+          :class="{ 'border-l-4 border-terracotta': toast.type === 'error', 'border-l-4 border-olive': toast.type === 'success' }"
+        >
+          <p class="text-sm text-dusk" x-text="toast.message"></p>
+        </div>
+      </template>
+    </div>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       as="image"
       href="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&amp;fit=crop&amp;w=2000&amp;q=80"
     />
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   </head>
   <body class="bg-sand text-dusk">
     <div class="flex min-h-screen flex-col">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2593 @@
+{
+  "name": "cittafutura",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cittafutura",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "alpinejs": "^3.15.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/forms": "^0.5.10",
+        "autoprefixer": "^10.4.21",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^3.4.4",
+        "vite": "^5.4.10"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.2.tgz",
+      "integrity": "sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.2.tgz",
+      "integrity": "sha512-oEouqQk2/zxxj22PNcGSskya+3kV0ZKH+nQxuCCOGJ4oTXBdNTbv+f/E3c74cNLeMO1S5wVWacSws10TTSB77g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.2.tgz",
+      "integrity": "sha512-OZuTVTpj3CDSIxmPgGH8en/XtirV5nfljHZ3wrNwvgkT5DQLhIKAeuFSiwtbMto6oVexV0k1F1zqURPKf5rI1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.2.tgz",
+      "integrity": "sha512-Wa/Wn8RFkIkr1vy1k1PB//VYhLnlnn5eaJkfTQKivirOvzu5uVd2It01ukeQstMursuz7S1bU+8WW+1UPXpa8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.2.tgz",
+      "integrity": "sha512-QkzxvH3kYN9J1w7D1A+yIMdI1pPekD+pWx7G5rXgnIlQ1TVYVC6hLl7SOV9pi5q9uIDF9AuIGkuzcbF7+fAhow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.2.tgz",
+      "integrity": "sha512-dkYXB0c2XAS3a3jmyDkX4Jk0m7gWLFzq1C3qUnJJ38AyxIF5G/dyS4N9B30nvFseCfgtCEdbYFhk0ChoCGxPog==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.2.tgz",
+      "integrity": "sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.2.tgz",
+      "integrity": "sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.2.tgz",
+      "integrity": "sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.2.tgz",
+      "integrity": "sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.50.2.tgz",
+      "integrity": "sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.2.tgz",
+      "integrity": "sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.2.tgz",
+      "integrity": "sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.2.tgz",
+      "integrity": "sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.2.tgz",
+      "integrity": "sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.2.tgz",
+      "integrity": "sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.2.tgz",
+      "integrity": "sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.2.tgz",
+      "integrity": "sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.2.tgz",
+      "integrity": "sha512-eFUvvnTYEKeTyHEijQKz81bLrUQOXKZqECeiWH6tb8eXXbZk+CXSG2aFrig2BQ/pjiVRj36zysjgILkqarS2YA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.2.tgz",
+      "integrity": "sha512-cBaWmXqyfRhH8zmUxK3d3sAhEWLrtMjWBRwdMMHJIXSjvjLKvv49adxiEz+FJ8AP90apSDDBx2Tyd/WylV6ikA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.2.tgz",
+      "integrity": "sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.10.tgz",
+      "integrity": "sha512-utI1ONF6uf/pPNO68kmN1b8rEwNXv3czukalo8VtJH8ksIkZXr3Q3VYudZLkCsDd4Wku120uF02hYK25XGPorw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
+      "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.1.5"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
+      "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
+      "license": "MIT"
+    },
+    "node_modules/alpinejs": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.0.tgz",
+      "integrity": "sha512-lpokA5okCF1BKh10LG8YjqhfpxyHBk4gE7boIgVHltJzYoM7O9nK3M7VlntLEJGsVmu7U/RzUWajmHREGT38Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "~3.1.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.5.tgz",
+      "integrity": "sha512-TiU4qUT9jdCuh4aVOG7H1QozyeI2sZRqoRPdqBIaslfNt4WUSanRBueAwl2x5jt4rXBMim3lIN2x6yT8PDi24Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
+      "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.3",
+        "caniuse-lite": "^1.0.30001741",
+        "electron-to-chromium": "^1.5.218",
+        "node-releases": "^2.0.21",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001743",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
+      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.221",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.221.tgz",
+      "integrity": "sha512-/1hFJ39wkW01ogqSyYoA4goOXOtMRy6B+yvA1u42nnsEGtHzIzmk93aPISumVQeblj47JUHLC9coCjUxb1EvtQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+      "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.50.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.2.tgz",
+      "integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.50.2",
+        "@rollup/rollup-android-arm64": "4.50.2",
+        "@rollup/rollup-darwin-arm64": "4.50.2",
+        "@rollup/rollup-darwin-x64": "4.50.2",
+        "@rollup/rollup-freebsd-arm64": "4.50.2",
+        "@rollup/rollup-freebsd-x64": "4.50.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.50.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.50.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.50.2",
+        "@rollup/rollup-linux-arm64-musl": "4.50.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.50.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.50.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.50.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.50.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.50.2",
+        "@rollup/rollup-linux-x64-gnu": "4.50.2",
+        "@rollup/rollup-linux-x64-musl": "4.50.2",
+        "@rollup/rollup-openharmony-arm64": "4.50.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.50.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.50.2",
+        "@rollup/rollup-win32-x64-msvc": "4.50.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.4.tgz",
+      "integrity": "sha512-ZoyXOdJjISB7/BcLTR6SEsLgKtDStYyYZVLsUtWChO4Ps20CBad7lfJKVDiejocV4ME1hLmyY0WJE3hSDcmQ2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.5.3",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.0",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.0",
+        "lilconfig": "^2.1.0",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.23",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.1",
+        "postcss-nested": "^6.0.1",
+        "postcss-selector-parser": "^6.0.11",
+        "resolve": "^1.22.2",
+        "sucrase": "^3.32.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "cittafutura",
+  "version": "1.0.0",
+  "description": "Le case di Città Futura static site",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "alpinejs": "^3.15.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/forms": "^0.5.10",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.4",
+    "vite": "^5.4.10"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title data-i18n="privacy.page.title">Informativa privacy</title>
+    <script type="module" src="/src/main.js"></script>
+  </head>
+  <body class="bg-sand text-dusk">
+    <div class="flex min-h-screen flex-col">
+      <header class="bg-sand/95 shadow-sm">
+        <nav class="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4">
+          <a href="./" class="flex items-center space-x-2" aria-label="Home">
+            <span class="rounded-full bg-terracotta px-3 py-1 text-xs font-semibold uppercase tracking-widest text-white">CF</span>
+            <span class="font-display text-lg" data-i18n="site.name">Le case di Città Futura</span>
+          </a>
+          <div class="flex items-center space-x-6 text-sm font-medium">
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="index.html" data-i18n="nav.home">Home</a>
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="houses.html" data-i18n="nav.houses">Case</a>
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="book.html" data-i18n="nav.book">Prenota</a>
+            <a class="hover:text-terracotta focus-visible:outline focus-visible:outline-terracotta" href="admin.html" data-i18n="nav.admin">Admin</a>
+            <div x-data="languageSwitcher" class="relative">
+              <button
+                @click="toggle"
+                @keydown.escape="close"
+                class="flex items-center space-x-1 rounded-full border border-terracotta px-3 py-1 text-xs font-semibold text-terracotta focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-terracotta"
+                :aria-expanded="open"
+                type="button"
+              >
+                <span x-text="current.toUpperCase()"></span>
+                <svg class="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.186l3.71-3.955a.75.75 0 011.08 1.04l-4.24 4.52a.75.75 0 01-1.08 0l-4.24-4.52a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
+                </svg>
+              </button>
+              <div x-show="open" x-transition.opacity @click.away="close" class="absolute right-0 mt-2 w-36 rounded-xl bg-white p-2 shadow-lg ring-1 ring-black/5">
+                <button class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-sand" type="button" @click="switchTo('it')">
+                  <span data-i18n="nav.language.it">Italiano</span>
+                </button>
+                <button class="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-sand" type="button" @click="switchTo('en')">
+                  <span data-i18n="nav.language.en">English</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </nav>
+      </header>
+
+      <main class="flex-1 bg-gradient-to-b from-white to-sand">
+        <section class="mx-auto max-w-4xl px-6 py-12 space-y-6">
+          <h1 class="font-display text-3xl" data-i18n="privacy.page.title">Informativa privacy</h1>
+          <p class="text-lg text-dusk/80" data-i18n="privacy.page.subtitle">
+            Trasparenza su come trattiamo i tuoi dati per la prenotazione e la gestione delle case.
+          </p>
+          <div class="space-y-8 text-sm leading-relaxed">
+            <section class="space-y-2">
+              <h2 class="text-xl font-semibold" data-i18n="privacy.section.data.title">Dati trattati</h2>
+              <p data-i18n="privacy.section.data.text">
+                Raccogliamo nome, contatti, informazioni sul soggiorno e note fornite volontariamente. I dati sono salvati in file JSON nel repository GitHub del progetto.
+              </p>
+            </section>
+            <section class="space-y-2">
+              <h2 class="text-xl font-semibold" data-i18n="privacy.section.use.title">Finalità</h2>
+              <p data-i18n="privacy.section.use.text">
+                Utilizziamo i dati solo per gestire la richiesta di soggiorno, comunicare con te e adempiere agli obblighi legali.
+              </p>
+            </section>
+            <section class="space-y-2">
+              <h2 class="text-xl font-semibold" data-i18n="privacy.section.share.title">Condivisione</h2>
+              <p data-i18n="privacy.section.share.text">
+                I dati sono accessibili ai manutentori del progetto su GitHub. Nessun dato è condiviso con terze parti commerciali.
+              </p>
+            </section>
+            <section class="space-y-2">
+              <h2 class="text-xl font-semibold" data-i18n="privacy.section.retention.title">Conservazione</h2>
+              <p data-i18n="privacy.section.retention.text">
+                Cancelliamo i dati su richiesta o dopo la chiusura del soggiorno. I file possono essere rimossi tramite la pagina Admin.
+              </p>
+            </section>
+            <section class="space-y-2">
+              <h2 class="text-xl font-semibold" data-i18n="privacy.section.rights.title">Diritti</h2>
+              <p data-i18n="privacy.section.rights.text">
+                Per accedere, rettificare o cancellare i dati scrivici a cittafutura@example.org.
+              </p>
+            </section>
+          </div>
+        </section>
+      </main>
+
+      <footer class="bg-dusk text-sand">
+        <div class="mx-auto max-w-5xl space-y-4 px-6 py-10 text-sm">
+          <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <p data-i18n="footer.rights">© Città Futura. Tutti i diritti riservati.</p>
+            <p data-i18n="footer.credit.photos">
+              Foto: Luca Bravo, Cristina Gottardi, Federico Di Dio, Jason Blackeye, Tim Graf, Shifaaz Shamoon via Unsplash (licenza Unsplash).
+            </p>
+          </div>
+          <p data-i18n="footer.credit.contact">Per collaborare: cittafutura@example.org</p>
+        </div>
+      </footer>
+    </div>
+
+    <div class="pointer-events-none fixed inset-0 z-[60] flex flex-col items-end space-y-2 p-4" x-data>
+      <template x-for="toast in $store.toast.items" :key="toast.id">
+        <div
+          class="pointer-events-auto w-full max-w-xs rounded-2xl bg-white p-4 shadow-lg ring-1 ring-black/5"
+          :class="{ 'border-l-4 border-terracotta': toast.type === 'error', 'border-l-4 border-olive': toast.type === 'success' }"
+        >
+          <p class="text-sm text-dusk" x-text="toast.message"></p>
+        </div>
+      </template>
+    </div>
+  </body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title data-i18n="privacy.page.title">Informativa privacy</title>
-    <script type="module" src="/src/main.js"></script>
+    <script type="module" src="./src/main.js"></script>
   </head>
   <body class="bg-sand text-dusk">
     <div class="flex min-h-screen flex-col">

--- a/public/.well-known/config.json
+++ b/public/.well-known/config.json
@@ -1,0 +1,9 @@
+{
+  "githubClientId": "YOUR_GITHUB_CLIENT_ID",
+  "oauthProxyUrl": "https://your-proxy.example.com/api/exchange",
+  "staticman": {
+    "enabled": true,
+    "endpoint": "https://api.staticman.net/v3/entry/github/your-org/cittafutura/main/bookings"
+  },
+  "bookingIssueFallbackUrl": "https://github.com/your-org/cittafutura/issues/new?template=booking.md"
+}

--- a/public/houses/README.md
+++ b/public/houses/README.md
@@ -1,0 +1,4 @@
+# Gallery case
+
+Per la demo le foto delle case sono caricate da URL esterni (Unsplash) per evitare asset binari nel repository.
+Quando aggiungi immagini reali tramite l'area admin verranno salvate in sotto-cartelle (`public/houses/<slug>/`).

--- a/public/img/README.md
+++ b/public/img/README.md
@@ -1,0 +1,4 @@
+# Immagini generiche
+
+Le immagini della demo sono caricate da sorgenti esterne (Unsplash) per evitare di committare file binari.
+Usa questa cartella per aggiungere asset locali se necessario, assicurandoti di rispettare le licenze.

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,253 @@
+export const defaultLanguage = 'it';
+export const languages = ['it', 'en'];
+
+export const dictionary = {
+  'site.name': {
+    it: 'Le case di Città Futura',
+    en: 'The homes of Città Futura',
+  },
+  'nav.home': { it: 'Home', en: 'Home' },
+  'nav.houses': { it: 'Case', en: 'Houses' },
+  'nav.book': { it: 'Prenota', en: 'Book' },
+  'nav.admin': { it: 'Admin', en: 'Admin' },
+  'nav.language.it': { it: 'Italiano', en: 'Italian' },
+  'nav.language.en': { it: 'English', en: 'English' },
+  'hero.title': {
+    it: 'Ospitalità solidale nel cuore di Riace',
+    en: 'Solidarity hospitality in the heart of Riace',
+  },
+  'hero.subtitle': {
+    it: 'Accogliamo viaggiatori e nuove comunità in case condivise, per vivere la Calabria con lentezza e rispetto.',
+    en: 'We welcome travellers and new communities in shared homes, to experience Calabria with care and slowness.',
+  },
+  'hero.cta.houses': { it: 'Vedi case', en: 'View houses' },
+  'hero.cta.book': { it: 'Prenota', en: 'Book now' },
+  'mission.title': {
+    it: 'Ospitalità che crea comunità',
+    en: 'Hospitality that builds community',
+  },
+  'mission.text': {
+    it: 'Città Futura nasce dall’esperienza di accoglienza di Riace. Le nostre case sono aperte a chi cerca un soggiorno autentico, etico e vicino alle persone che abitano questi luoghi.',
+    en: 'Città Futura stems from Riace’s welcoming experience. Our homes are open to anyone looking for an authentic, ethical stay in touch with the people who live here.',
+  },
+  'mission.values.community.title': { it: 'Comunità', en: 'Community' },
+  'mission.values.community.text': {
+    it: 'Ogni soggiorno sostiene la rete di vicinato, i laboratori artigiani e i progetti sociali locali.',
+    en: 'Every stay supports the neighbourhood network, artisan workshops and local social projects.',
+  },
+  'mission.values.inclusion.title': { it: 'Inclusione', en: 'Inclusion' },
+  'mission.values.inclusion.text': {
+    it: 'Le case sono gestite insieme a famiglie del territorio e persone rifugiate, con attenzione ai bisogni di tutte e tutti.',
+    en: 'Homes are managed together with local families and people seeking refuge, with attention to everyone’s needs.',
+  },
+  'mission.values.environment.title': { it: 'Territorio', en: 'Territory' },
+  'mission.values.environment.text': {
+    it: 'Promuoviamo un turismo lento: consigli su come muoversi senza auto e scoprire le bellezze dello Ionio.',
+    en: 'We promote slow tourism: tips on moving without a car and discovering the Ionian coast’s beauty.',
+  },
+  'gallery.title': { it: 'Scopri Riace', en: 'Discover Riace' },
+  'gallery.caption': {
+    it: 'Paesaggi, colori e comunità che rendono unico questo luogo.',
+    en: 'Landscapes, colours and communities that make this place unique.',
+  },
+  'houses.preview.title': { it: 'Le nostre case', en: 'Our homes' },
+  'houses.preview.subtitle': {
+    it: 'Ogni appartamento racconta una storia di accoglienza condivisa. Prenota ora per vivere l’esperienza.',
+    en: 'Each apartment tells a story of shared hospitality. Book now to live the experience.',
+  },
+  'houses.preview.cta': { it: 'Tutte le case', en: 'All houses' },
+  'footer.rights': {
+    it: '© Città Futura. Tutti i diritti riservati.',
+    en: '© Città Futura. All rights reserved.',
+  },
+  'footer.credit.photos': {
+    it: 'Foto: Luca Bravo, Cristina Gottardi, Federico Di Dio, Jason Blackeye, Tim Graf, Shifaaz Shamoon via Unsplash (licenza Unsplash).',
+    en: 'Photos: Luca Bravo, Cristina Gottardi, Federico Di Dio, Jason Blackeye, Tim Graf, Shifaaz Shamoon via Unsplash (Unsplash License).',
+  },
+  'footer.credit.contact': {
+    it: 'Per collaborare: cittafutura@example.org',
+    en: 'Collaborations: cittafutura@example.org',
+  },
+  'houses.page.title': { it: 'Case disponibili', en: 'Available homes' },
+  'houses.page.subtitle': {
+    it: 'Spazi accoglienti curati dalla comunità di Riace. Contattaci se hai esigenze specifiche.',
+    en: 'Welcoming spaces cared for by Riace’s community. Contact us if you have specific needs.',
+  },
+  'houses.page.empty': {
+    it: 'Nessuna casa disponibile al momento.',
+    en: 'No homes available at the moment.',
+  },
+  'houses.card.book': { it: 'Prenota', en: 'Book' },
+  'book.page.title': { it: 'Richiedi una prenotazione', en: 'Request a booking' },
+  'book.page.subtitle': {
+    it: 'Compila il form: il team di Città Futura approverà la richiesta appena possibile.',
+    en: 'Fill in the form: the Città Futura team will approve your request as soon as possible.',
+  },
+  'book.form.house': { it: 'Casa', en: 'House' },
+  'book.form.selectHouse': { it: 'Scegli una casa', en: 'Select a house' },
+  'book.form.name': { it: 'Nome e cognome', en: 'Full name' },
+  'book.form.email': { it: 'Email', en: 'Email' },
+  'book.form.phone': { it: 'Telefono', en: 'Phone' },
+  'book.form.checkin': { it: 'Arrivo', en: 'Arrival' },
+  'book.form.checkout': { it: 'Partenza', en: 'Departure' },
+  'book.form.people': { it: 'Persone', en: 'Guests' },
+  'book.form.notes': { it: 'Note', en: 'Notes' },
+  'book.form.notes.placeholder': {
+    it: 'Allergie, richieste specifiche…',
+    en: 'Allergies, specific requests…',
+  },
+  'book.form.privacy': {
+    it: "Ho letto e accetto l'informativa privacy",
+    en: 'I have read and accept the privacy policy',
+  },
+  'book.form.privacy.link': { it: 'Informativa privacy', en: 'Privacy policy' },
+  'book.form.submit': { it: 'Invia richiesta', en: 'Send request' },
+  'book.form.submitting': { it: 'Invio in corso…', en: 'Sending…' },
+  'book.form.success': {
+    it: 'Richiesta inviata! Riceverai una conferma via email dopo l’approvazione.',
+    en: 'Request sent! You will receive confirmation via email after approval.',
+  },
+  'book.form.error': {
+    it: 'Non è stato possibile inviare la richiesta. Riprova tra poco o usa il canale alternativo.',
+    en: 'The request could not be sent. Please try again soon or use the alternative channel.',
+  },
+  'book.form.invalidDates': {
+    it: 'La data di partenza deve essere successiva a quella di arrivo.',
+    en: 'Departure must be after arrival.',
+  },
+  'book.form.honeypot': {
+    it: 'Lascia questo campo vuoto',
+    en: 'Leave this field blank',
+  },
+  'book.form.required': { it: 'Campo obbligatorio', en: 'Required field' },
+  'book.form.altChannel': {
+    it: 'In alternativa puoi aprire una richiesta su GitHub.',
+    en: 'Alternatively you can open a request on GitHub.',
+  },
+  'book.form.openIssue': { it: 'Apri richiesta su GitHub', en: 'Open request on GitHub' },
+  'book.form.rateLimited': {
+    it: 'Stiamo già inviando una richiesta. Attendi qualche secondo prima di riprovare.',
+    en: 'A request is already being sent. Please wait a few seconds before retrying.',
+  },
+  'book.form.validation': {
+    it: 'Compila tutti i campi richiesti.',
+    en: 'Please fill in all required fields.',
+  },
+  'privacy.page.title': { it: 'Informativa privacy', en: 'Privacy policy' },
+  'privacy.page.subtitle': {
+    it: 'Trasparenza su come trattiamo i tuoi dati per la prenotazione e la gestione delle case.',
+    en: 'Transparency on how we handle your data for bookings and house management.',
+  },
+  'privacy.section.data.title': {
+    it: 'Dati trattati',
+    en: 'Data processed',
+  },
+  'privacy.section.data.text': {
+    it: 'Raccogliamo nome, contatti, informazioni sul soggiorno e note fornite volontariamente. I dati sono salvati in file JSON nel repository GitHub del progetto.',
+    en: 'We collect name, contacts, stay information and notes voluntarily provided. Data is stored in JSON files inside the project GitHub repository.',
+  },
+  'privacy.section.use.title': {
+    it: 'Finalità',
+    en: 'Purposes',
+  },
+  'privacy.section.use.text': {
+    it: 'Utilizziamo i dati solo per gestire la richiesta di soggiorno, comunicare con te e adempiere agli obblighi legali.',
+    en: 'We use the data only to manage your stay request, communicate with you and comply with legal obligations.',
+  },
+  'privacy.section.share.title': {
+    it: 'Condivisione',
+    en: 'Sharing',
+  },
+  'privacy.section.share.text': {
+    it: 'I dati sono accessibili ai manutentori del progetto su GitHub. Nessun dato è condiviso con terze parti commerciali.',
+    en: 'Data is accessible to project maintainers on GitHub. No data is shared with commercial third parties.',
+  },
+  'privacy.section.retention.title': {
+    it: 'Conservazione',
+    en: 'Retention',
+  },
+  'privacy.section.retention.text': {
+    it: 'Cancelliamo i dati su richiesta o dopo la chiusura del soggiorno. I file possono essere rimossi tramite la pagina Admin.',
+    en: 'We delete data upon request or after the stay is closed. Files can be removed via the Admin page.',
+  },
+  'privacy.section.rights.title': {
+    it: 'Diritti',
+    en: 'Rights',
+  },
+  'privacy.section.rights.text': {
+    it: 'Per accedere, rettificare o cancellare i dati scrivici a cittafutura@example.org.',
+    en: 'To access, rectify or erase data write to cittafutura@example.org.',
+  },
+  'admin.page.title': { it: 'Pannello di amministrazione', en: 'Administration panel' },
+  'admin.page.subtitle': {
+    it: 'Gestisci prenotazioni e gallerie. Accesso riservato ai collaboratori della repo GitHub.',
+    en: 'Manage bookings and galleries. Access reserved to collaborators of the GitHub repository.',
+  },
+  'admin.auth.login': { it: 'Accedi con GitHub', en: 'Sign in with GitHub' },
+  'admin.auth.logout': { it: 'Disconnetti', en: 'Sign out' },
+  'admin.auth.checking': {
+    it: 'Verifica permessi…',
+    en: 'Checking permissions…',
+  },
+  'admin.auth.denied': {
+    it: 'Non hai i permessi necessari per modificare questo progetto.',
+    en: 'You do not have the required permissions to modify this project.',
+  },
+  'admin.bookings.title': { it: 'Prenotazioni', en: 'Bookings' },
+  'admin.bookings.empty': { it: 'Nessuna prenotazione registrata.', en: 'No bookings recorded.' },
+  'admin.filters.status.all': { it: 'Tutti gli stati', en: 'All statuses' },
+  'admin.filters.search': { it: 'Cerca per nome o email…', en: 'Search by name or email…' },
+  'admin.bookings.table.headers.house': { it: 'Casa', en: 'House' },
+  'admin.bookings.table.headers.name': { it: 'Ospite', en: 'Guest' },
+  'admin.bookings.table.headers.dates': { it: 'Date', en: 'Dates' },
+  'admin.bookings.table.headers.people': { it: 'Persone', en: 'Guests' },
+  'admin.bookings.table.headers.status': { it: 'Stato', en: 'Status' },
+  'admin.bookings.table.headers.actions': { it: 'Azioni', en: 'Actions' },
+  'admin.actions.approve': { it: 'Approva', en: 'Approve' },
+  'admin.actions.reject': { it: 'Rifiuta', en: 'Reject' },
+  'admin.actions.cancel': { it: 'Annulla', en: 'Cancel' },
+  'admin.actions.edit': { it: 'Modifica', en: 'Edit' },
+  'admin.actions.delete': { it: 'Elimina', en: 'Delete' },
+  'admin.actions.save': { it: 'Salva', en: 'Save' },
+  'admin.actions.close': { it: 'Chiudi', en: 'Close' },
+  'admin.actions.export': { it: 'Esporta CSV', en: 'Export CSV' },
+  'admin.confirm.delete.title': { it: 'Confermi eliminazione?', en: 'Confirm deletion?' },
+  'admin.confirm.delete.body': {
+    it: 'L’operazione è irreversibile. Il file sarà rimosso dal repository.',
+    en: 'This action cannot be undone. The file will be removed from the repository.',
+  },
+  'admin.toasts.saved': { it: 'Prenotazione aggiornata.', en: 'Booking updated.' },
+  'admin.toasts.deleted': { it: 'Prenotazione eliminata.', en: 'Booking deleted.' },
+  'admin.toasts.uploaded': { it: 'Immagine caricata.', en: 'Image uploaded.' },
+  'admin.toasts.error': { it: 'Si è verificato un errore.', en: 'An error occurred.' },
+  'admin.images.title': { it: 'Foto case', en: 'House photos' },
+  'admin.images.subtitle': {
+    it: 'Carica nuove immagini (JPG/PNG, max 2MB). Usa i pulsanti per riordinare e impostare la cover.',
+    en: 'Upload new images (JPG/PNG, max 2MB). Use the buttons to reorder and set the cover.',
+  },
+  'admin.images.upload': { it: 'Carica immagine', en: 'Upload image' },
+  'admin.images.remove': { it: 'Rimuovi', en: 'Remove' },
+  'admin.images.setCover': { it: 'Imposta cover', en: 'Set cover' },
+  'admin.images.empty': { it: 'Nessuna immagine disponibile.', en: 'No image available.' },
+  'admin.images.moveUp': { it: 'Su', en: 'Up' },
+  'admin.images.moveDown': { it: 'Giù', en: 'Down' },
+  'admin.images.coverBadge': { it: 'Cover', en: 'Cover' },
+  'admin.images.fileTooLarge': {
+    it: 'File troppo grande (max 2MB)',
+    en: 'File too large (max 2MB)',
+  },
+  'admin.bookings.status.pending': { it: 'In attesa', en: 'Pending' },
+  'admin.bookings.status.approved': { it: 'Approvata', en: 'Approved' },
+  'admin.bookings.status.rejected': { it: 'Rifiutata', en: 'Rejected' },
+  'admin.bookings.status.canceled': { it: 'Annullata', en: 'Cancelled' },
+  'admin.export.filename': {
+    it: 'prenotazioni-citta-futura.csv',
+    en: 'citta-futura-bookings.csv',
+  },
+  'admin.bookings.lastUpdated': {
+    it: 'Ultimo aggiornamento',
+    en: 'Last updated',
+  },
+  'admin.images.update': { it: 'Salva galleria', en: 'Save gallery' },
+  'admin.bookings.refresh': { it: 'Aggiorna elenco', en: 'Refresh list' },
+};

--- a/src/main.css
+++ b/src/main.css
@@ -1,0 +1,54 @@
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:wght@600&family=Work+Sans:wght@400;500;600&display=swap');
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  html {
+    scroll-behavior: smooth;
+  }
+
+  body {
+    @apply font-sans text-dusk bg-sand antialiased;
+  }
+}
+
+@layer components {
+  .btn-primary {
+    @apply inline-flex items-center justify-center rounded-full bg-terracotta px-6 py-3 text-sm font-semibold text-white transition-opacity duration-300 ease-out hover:bg-terracotta/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-terracotta;
+  }
+
+  .btn-secondary {
+    @apply inline-flex items-center justify-center rounded-full border border-terracotta px-6 py-3 text-sm font-semibold text-terracotta transition-opacity duration-300 ease-out hover:bg-terracotta/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-terracotta;
+  }
+
+  .card {
+    @apply rounded-3xl bg-white shadow-lg shadow-dusk/10 transition duration-500 ease-out hover:-translate-y-1 hover:shadow-xl;
+  }
+
+  .tag {
+    @apply inline-flex items-center rounded-full bg-sand px-3 py-1 text-xs font-medium text-terracotta;
+  }
+
+  .fade-enter {
+    @apply opacity-0 translate-y-4;
+  }
+
+  .fade-enter-active {
+    @apply opacity-100 translate-y-0 transition duration-700 ease-out;
+  }
+
+  .fade-loop {
+    @apply transition-opacity duration-700 ease-in-out;
+  }
+}
+
+.lazy-image {
+  opacity: 0;
+  transition: opacity 0.7s ease-in-out;
+}
+
+.lazy-image[data-loaded="true"] {
+  opacity: 1;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,460 @@
+import Alpine from 'alpinejs';
+import './main.css';
+import { initLanguage, setLanguage, getCurrentLanguage, t } from './services/i18n.js';
+import { registerToastStore } from './ui/toast.js';
+import { registerAnimations } from './ui/intersection.js';
+import { submitBooking, isSubmitting, getFallbackLink, getErrorMessage } from './services/booking.js';
+import { getConfig } from './services/config.js';
+import { buildAuthorizeUrl, exchangeCodeForToken, createClientFromConfig, parseRepoFromConfig } from './services/gh.js';
+import { resolveSitePath } from './services/url.js';
+
+window.Alpine = Alpine;
+
+document.addEventListener('alpine:init', () => {
+  registerToastStore();
+
+  Alpine.store('lang', {
+    current: getCurrentLanguage(),
+    set(lang) {
+      this.current = lang;
+    },
+  });
+
+  Alpine.data('languageSwitcher', () => ({
+    open: false,
+    get current() {
+      return Alpine.store('lang').current;
+    },
+    toggle() {
+      this.open = !this.open;
+    },
+    close() {
+      this.open = false;
+    },
+    switchTo(lang) {
+      setLanguage(lang);
+      this.close();
+    },
+  }));
+
+  Alpine.data('housesList', () => ({
+    houses: [],
+    loading: true,
+    error: null,
+    async init() {
+      try {
+        const response = await fetch(resolveSitePath('data/houses.json'), { cache: 'no-cache' });
+        if (!response.ok) {
+          throw new Error('http-error');
+        }
+        const data = await response.json();
+        this.houses = data.filter((house) => house.active !== false);
+      } catch (error) {
+        console.error('Unable to load houses', error);
+        this.error = error;
+      } finally {
+        this.loading = false;
+      }
+    },
+    nameFor(house) {
+      const lang = Alpine.store('lang').current;
+      return house.name?.[lang] ?? house.name?.it ?? '';
+    },
+    summaryFor(house) {
+      const lang = Alpine.store('lang').current;
+      return house.summary?.[lang] ?? house.summary?.it ?? '';
+    },
+    bookUrl(house) {
+      if (!house?.id) {
+        return resolveSitePath('book.html');
+      }
+      return resolveSitePath(`book.html?house=${encodeURIComponent(house.id)}`);
+    },
+  }));
+
+  Alpine.data('bookingForm', () => ({
+    houses: [],
+    fallbackLink: '',
+    status: 'idle',
+    message: '',
+    get lang() {
+      return Alpine.store('lang').current;
+    },
+    tKey(key) {
+      return t(key);
+    },
+    async init() {
+      const config = await getConfig();
+      this.fallbackLink = getFallbackLink(config);
+      await this.loadHouses();
+      const params = new URLSearchParams(window.location.search);
+      const selected = params.get('house');
+      if (selected && this.houses.some((house) => house.id === selected)) {
+        this.$refs.houseSelect.value = selected;
+      }
+    },
+    async loadHouses() {
+      try {
+        const response = await fetch(resolveSitePath('data/houses.json'), { cache: 'no-cache' });
+        if (!response.ok) {
+          throw new Error('http-error');
+        }
+        this.houses = await response.json();
+        this.houses = this.houses.filter((house) => house.active !== false);
+      } catch (error) {
+        console.error('Unable to fetch houses', error);
+        this.houses = [];
+      }
+    },
+    async submit() {
+      if (isSubmitting()) {
+        this.message = t('book.form.rateLimited');
+        this.status = 'error';
+        return;
+      }
+      const form = this.$refs.form;
+      if (!form.reportValidity()) {
+        this.message = t('book.form.validation');
+        this.status = 'error';
+        return;
+      }
+      const formData = new FormData(form);
+      this.status = 'loading';
+      this.message = '';
+      try {
+        await submitBooking(formData);
+        this.status = 'success';
+        this.message = t('book.form.success');
+        form.reset();
+        Alpine.store('toast').show(this.message, 'success');
+      } catch (error) {
+        console.error('Booking error', error);
+        this.status = 'error';
+        this.message = getErrorMessage(error);
+      }
+    },
+  }));
+
+  Alpine.data('adminApp', () => ({
+    config: null,
+    repoInfo: null,
+    token: null,
+    client: null,
+    authenticated: false,
+    checkingPermissions: false,
+    loading: false,
+    error: null,
+    bookings: [],
+    houses: [],
+    housesSha: null,
+    filters: {
+      status: 'all',
+      search: '',
+    },
+    lastUpdated: null,
+    modalOpen: false,
+    editableBooking: null,
+    oauthState: null,
+    async init() {
+      this.loading = true;
+      this.config = await getConfig();
+      this.repoInfo = parseRepoFromConfig(this.config);
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get('code');
+      const stateParam = params.get('state');
+      const storedToken = sessionStorage.getItem('cf-gh-token');
+      if (storedToken) {
+        this.token = storedToken;
+      }
+      this.oauthState = sessionStorage.getItem('cf-gh-state');
+      if (code) {
+        try {
+          if (stateParam && this.oauthState && stateParam !== this.oauthState) {
+            throw new Error('oauth-state-mismatch');
+          }
+          const { access_token } = await exchangeCodeForToken(code);
+          this.token = access_token;
+          sessionStorage.setItem('cf-gh-token', access_token);
+          if (this.oauthState) {
+            sessionStorage.removeItem('cf-gh-state');
+            this.oauthState = null;
+          }
+          params.delete('code');
+          params.delete('state');
+          const newUrl = `${window.location.pathname}${params.toString() ? `?${params.toString()}` : ''}`;
+          window.history.replaceState({}, document.title, newUrl);
+        } catch (error) {
+          console.error('OAuth error', error);
+          this.error = 'oauth';
+        }
+      }
+      if (this.token) {
+        await this.bootstrap();
+      }
+      this.loading = false;
+    },
+    login() {
+      if (!this.config?.githubClientId) {
+        this.error = 'missing-client';
+        return;
+      }
+      const state = crypto.randomUUID();
+      sessionStorage.setItem('cf-gh-state', state);
+      const url = buildAuthorizeUrl(
+        this.config.githubClientId,
+        window.location.href,
+        state
+      );
+      window.location.href = url;
+    },
+    logout() {
+      sessionStorage.removeItem('cf-gh-token');
+      this.token = null;
+      this.authenticated = false;
+      this.client = null;
+    },
+    async bootstrap() {
+      try {
+        this.client = await createClientFromConfig();
+        this.client.setToken(this.token);
+        this.checkingPermissions = true;
+        const allowed = await this.client.hasWriteAccess();
+        this.checkingPermissions = false;
+        if (!allowed) {
+          this.error = 'forbidden';
+          return;
+        }
+        this.authenticated = true;
+        await this.refreshData();
+      } catch (error) {
+        console.error('Unable to bootstrap admin', error);
+        this.error = 'bootstrap';
+      }
+    },
+    async refreshData() {
+      if (!this.client) return;
+      this.loading = true;
+      try {
+        this.bookings = await this.client.listBookings();
+        const { houses, sha } = await this.client.listHouses();
+        this.houses = houses;
+        this.housesSha = sha;
+        this.lastUpdated = new Date().toISOString();
+      } catch (error) {
+        console.error('Unable to load data', error);
+        this.error = 'load';
+      } finally {
+        this.loading = false;
+      }
+    },
+    get filteredBookings() {
+      const search = this.filters.search.toLowerCase();
+      return this.bookings.filter((booking) => {
+        const statusMatch =
+          this.filters.status === 'all' || booking.status === this.filters.status;
+        const searchMatch =
+          !search ||
+          booking.name?.toLowerCase().includes(search) ||
+          booking.email?.toLowerCase().includes(search);
+        return statusMatch && searchMatch;
+      });
+    },
+    tKey(key) {
+      return t(key);
+    },
+    statusLabel(status) {
+      return t(`admin.bookings.status.${status}`);
+    },
+    formatDates(booking) {
+      const lang = Alpine.store('lang').current;
+      try {
+        const start = booking.checkin ? new Date(booking.checkin).toLocaleDateString(lang, { dateStyle: 'medium' }) : '';
+        const end = booking.checkout ? new Date(booking.checkout).toLocaleDateString(lang, { dateStyle: 'medium' }) : '';
+        return `${start} → ${end}`.trim();
+      } catch (error) {
+        return `${booking.checkin || ''} → ${booking.checkout || ''}`;
+      }
+    },
+    formatTimestamp(value) {
+      if (!value) return '';
+      const lang = Alpine.store('lang').current;
+      try {
+        return new Date(value).toLocaleString(lang, { dateStyle: 'short', timeStyle: 'short' });
+      } catch (error) {
+        return value;
+      }
+    },
+    houseName(id) {
+      const house = this.houses.find((item) => item.id === id);
+      if (!house) return id;
+      const lang = Alpine.store('lang').current;
+      return house.name?.[lang] ?? house.name?.it ?? id;
+    },
+    async changeStatus(booking, status) {
+      try {
+        await this.client.updateBookingStatus(booking, status);
+        Alpine.store('toast').show(t('admin.toasts.saved'), 'success');
+        await this.refreshData();
+      } catch (error) {
+        console.error('Status change failed', error);
+        Alpine.store('toast').show(t('admin.toasts.error'), 'error');
+      }
+    },
+    editBooking(booking) {
+      this.editableBooking = JSON.parse(JSON.stringify(booking));
+      this.modalOpen = true;
+    },
+    closeModal() {
+      this.modalOpen = false;
+      this.editableBooking = null;
+    },
+    async saveBooking() {
+      try {
+        await this.client.saveBooking(this.editableBooking);
+        Alpine.store('toast').show(t('admin.toasts.saved'), 'success');
+        this.closeModal();
+        await this.refreshData();
+      } catch (error) {
+        console.error('Save booking failed', error);
+        Alpine.store('toast').show(t('admin.toasts.error'), 'error');
+      }
+    },
+    async deleteBooking(booking) {
+      if (!confirm(t('admin.confirm.delete.body'))) {
+        return;
+      }
+      try {
+        await this.client.deleteBooking(booking);
+        Alpine.store('toast').show(t('admin.toasts.deleted'), 'success');
+        await this.refreshData();
+      } catch (error) {
+        console.error('Delete failed', error);
+        Alpine.store('toast').show(t('admin.toasts.error'), 'error');
+      }
+    },
+    peopleLabel(booking) {
+      return `${booking.people || 1}`;
+    },
+    async uploadImage(event, house) {
+      const [file] = event.target.files;
+      if (!file) return;
+      if (file.size > 2 * 1024 * 1024) {
+        Alpine.store('toast').show(t('admin.images.fileTooLarge'), 'error');
+        event.target.value = '';
+        return;
+      }
+      try {
+        const base64 = await this.readFileAsBase64(file);
+        const fileName = `${Date.now()}-${file.name}`.replace(/[^a-zA-Z0-9.-]/g, '_');
+        const path = `public/houses/${house.id}/${fileName}`;
+        await this.client.uploadImage({
+          path,
+          content: base64,
+          message: `chore: add image ${fileName}`,
+        });
+        house.gallery = house.gallery || [];
+        house.gallery.push(`/${path}`);
+        await this.saveHouses();
+        Alpine.store('toast').show(t('admin.toasts.uploaded'), 'success');
+        event.target.value = '';
+      } catch (error) {
+        console.error('Upload failed', error);
+        Alpine.store('toast').show(t('admin.toasts.error'), 'error');
+      }
+    },
+    async saveHouses() {
+      if (!this.client) return;
+      try {
+        await this.client.updateHouses({ houses: this.houses, sha: this.housesSha });
+        await this.refreshData();
+      } catch (error) {
+        console.error('Update houses failed', error);
+        Alpine.store('toast').show(t('admin.toasts.error'), 'error');
+      }
+    },
+    async removeImage(house, imagePath) {
+      const isRemote = /^https?:\/\//.test(imagePath);
+      try {
+        if (!isRemote) {
+          const relative = imagePath.replace(/^\//, '');
+          const detail = await this.client.getFile(relative);
+          await this.client.removeImage({ path: relative, sha: detail.sha });
+        }
+        house.gallery = house.gallery.filter((item) => item !== imagePath);
+        if (house.cover === imagePath) {
+          house.cover = house.gallery[0] || '';
+        }
+        await this.saveHouses();
+      } catch (error) {
+        console.error('Remove image failed', error);
+        Alpine.store('toast').show(t('admin.toasts.error'), 'error');
+      }
+    },
+    setCover(house, imagePath) {
+      house.cover = imagePath;
+      this.saveHouses();
+    },
+    moveImage(house, imagePath, direction) {
+      const index = house.gallery.indexOf(imagePath);
+      if (index === -1) return;
+      const target = index + direction;
+      if (target < 0 || target >= house.gallery.length) return;
+      const [item] = house.gallery.splice(index, 1);
+      house.gallery.splice(target, 0, item);
+      this.saveHouses();
+    },
+    exportCsv() {
+      if (!this.bookings.length) return;
+      const headers = ['id', 'houseId', 'name', 'email', 'phone', 'checkin', 'checkout', 'people', 'status', 'createdAt'];
+      const rows = [headers.join(',')];
+      this.bookings.forEach((booking) => {
+        const row = headers
+          .map((key) => {
+            const value = booking[key] ?? '';
+            return `"${String(value).replace(/"/g, '""')}"`;
+          })
+          .join(',');
+        rows.push(row);
+      });
+      const blob = new Blob([rows.join('\n')], { type: 'text/csv;charset=utf-8;' });
+      const link = document.createElement('a');
+      const url = URL.createObjectURL(blob);
+      link.href = url;
+      link.download = t('admin.export.filename');
+      link.click();
+      URL.revokeObjectURL(url);
+    },
+    readFileAsBase64(file) {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const result = reader.result;
+          const base64 = result.split(',')[1];
+          resolve(base64);
+        };
+        reader.onerror = (error) => reject(error);
+        reader.readAsDataURL(file);
+      });
+    },
+  }));
+});
+
+document.addEventListener('language:changed', (event) => {
+  if (window.Alpine && Alpine.store) {
+    try {
+      const store = Alpine.store('lang');
+      if (store) {
+        store.set(event.detail.lang);
+      }
+    } catch (error) {
+      console.warn('Unable to sync language store', error);
+    }
+  }
+});
+
+Alpine.start();
+
+window.addEventListener('DOMContentLoaded', () => {
+  initLanguage();
+  registerAnimations();
+});

--- a/src/services/booking.js
+++ b/src/services/booking.js
@@ -1,0 +1,96 @@
+import { getConfig } from './config.js';
+import { t } from './i18n.js';
+
+let submitting = false;
+
+export function isSubmitting() {
+  return submitting;
+}
+
+export async function submitBooking(formData) {
+  if (submitting) {
+    throw new Error('rate-limit');
+  }
+
+  const checkin = formData.get('checkin');
+  const checkout = formData.get('checkout');
+  if (checkin && checkout && new Date(checkin) >= new Date(checkout)) {
+    throw new Error('invalid-dates');
+  }
+
+  if (formData.get('website')) {
+    throw new Error('spam-detected');
+  }
+
+  submitting = true;
+  try {
+    const config = await getConfig();
+    if (!config.staticman?.enabled || !config.staticman.endpoint) {
+      throw new Error('staticman-disabled');
+    }
+
+    const id = crypto.randomUUID();
+    const createdAt = new Date().toISOString();
+    const safeTimestamp = createdAt.replace(/[:.]/g, '-');
+    const slug = `${safeTimestamp}_${id}`;
+
+    const payload = {
+      options: {
+        slug,
+      },
+      fields: {
+        id,
+        houseId: formData.get('houseId'),
+        name: formData.get('name'),
+        email: formData.get('email'),
+        phone: formData.get('phone'),
+        checkin,
+        checkout,
+        people: parseInt(formData.get('people'), 10) || 1,
+        notes: formData.get('notes') || '',
+        status: 'pending',
+        createdAt,
+        source: 'web-form',
+      },
+    };
+
+    const response = await fetch(config.staticman.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      const error = new Error('staticman-error');
+      error.responseText = text;
+      throw error;
+    }
+
+    return { ok: true };
+  } finally {
+    submitting = false;
+  }
+}
+
+export function getFallbackLink(config) {
+  if (config?.bookingIssueFallbackUrl) {
+    return config.bookingIssueFallbackUrl;
+  }
+  return 'https://github.com';
+}
+
+export function getErrorMessage(error) {
+  switch (error.message) {
+    case 'rate-limit':
+      return t('book.form.rateLimited');
+    case 'invalid-dates':
+      return t('book.form.invalidDates');
+    case 'staticman-disabled':
+      return `${t('book.form.error')} (${t('book.form.altChannel')})`;
+    default:
+      return t('book.form.error');
+  }
+}

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -1,0 +1,32 @@
+import { resolveSitePath } from './url.js';
+
+const CONFIG_URL = resolveSitePath('.well-known/config.json');
+
+let configPromise;
+
+export function getConfig() {
+  if (!configPromise) {
+    configPromise = fetch(CONFIG_URL, {
+      headers: { 'Cache-Control': 'no-cache' },
+    })
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`Unable to load configuration (${res.status})`);
+        }
+        return res.json();
+      })
+      .catch((error) => {
+        console.warn('[config] Fallback to defaults', error);
+        return {
+          githubClientId: 'YOUR_GITHUB_CLIENT_ID',
+          oauthProxyUrl: '',
+          staticman: {
+            enabled: false,
+            endpoint: '',
+          },
+          bookingIssueFallbackUrl: '',
+        };
+      });
+  }
+  return configPromise;
+}

--- a/src/services/gh.js
+++ b/src/services/gh.js
@@ -1,0 +1,276 @@
+import { getConfig } from './config.js';
+
+const API_BASE = 'https://api.github.com';
+const encoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+const decoder = typeof TextDecoder !== 'undefined' ? new TextDecoder() : null;
+
+function encodeContent(content) {
+  if (typeof window !== 'undefined' && window.btoa && encoder) {
+    const bytes = encoder.encode(content);
+    let binary = '';
+    bytes.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+    return window.btoa(binary);
+  }
+  return Buffer.from(content, 'utf8').toString('base64');
+}
+
+function decodeContent(content) {
+  if (typeof window !== 'undefined' && window.atob && decoder) {
+    const binary = window.atob(content);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return decoder.decode(bytes);
+  }
+  return Buffer.from(content, 'base64').toString('utf8');
+}
+
+export function parseRepoFromConfig(config) {
+  const endpoint = config?.staticman?.endpoint;
+  if (!endpoint) {
+    return null;
+  }
+  const parts = endpoint.split('/');
+  const idx = parts.findIndex((part) => part === 'github');
+  if (idx === -1) {
+    return null;
+  }
+  const owner = parts[idx + 1];
+  const repo = parts[idx + 2];
+  const branch = parts[idx + 3] || 'main';
+  if (!owner || !repo) {
+    return null;
+  }
+  return { owner, repo, branch };
+}
+
+export class GitHubClient {
+  constructor({ owner, repo, branch = 'main' }) {
+    this.owner = owner;
+    this.repo = repo;
+    this.branch = branch;
+    this.token = null;
+    this.user = null;
+  }
+
+  setToken(token) {
+    this.token = token;
+  }
+
+  async ensureUser() {
+    if (!this.user) {
+      this.user = await this.request('/user');
+    }
+    return this.user;
+  }
+
+  async request(path, { method = 'GET', headers = {}, body, raw = false } = {}) {
+    const response = await fetch(`${API_BASE}${path}`, {
+      method,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
+        ...headers,
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      const error = new Error(`github:${response.status}`);
+      error.status = response.status;
+      error.body = text;
+      throw error;
+    }
+
+    if (response.status === 204 || raw) {
+      return response;
+    }
+
+    return response.json();
+  }
+
+  async getRepoContents(path) {
+    return this.request(`/repos/${this.owner}/${this.repo}/contents/${path}?ref=${this.branch}`);
+  }
+
+  async getFile(path) {
+    const data = await this.request(`/repos/${this.owner}/${this.repo}/contents/${path}?ref=${this.branch}`);
+    let decoded = null;
+    try {
+      decoded = decodeContent(data.content);
+    } catch (error) {
+      decoded = null;
+    }
+    return { ...data, decoded };
+  }
+
+  async updateFile({ path, message, content, sha, encoded = false }) {
+    return this.request(`/repos/${this.owner}/${this.repo}/contents/${path}`, {
+      method: 'PUT',
+      body: {
+        message,
+        content: encoded ? content : encodeContent(content),
+        branch: this.branch,
+        sha,
+      },
+    });
+  }
+
+  async createFile({ path, message, content, encoded = false }) {
+    return this.request(`/repos/${this.owner}/${this.repo}/contents/${path}`, {
+      method: 'PUT',
+      body: {
+        message,
+        content: encoded ? content : encodeContent(content),
+        branch: this.branch,
+      },
+    });
+  }
+
+  async deleteFile({ path, message, sha }) {
+    return this.request(`/repos/${this.owner}/${this.repo}/contents/${path}`, {
+      method: 'DELETE',
+      body: {
+        message,
+        branch: this.branch,
+        sha,
+      },
+    });
+  }
+
+  async listBookings() {
+    try {
+      const files = await this.getRepoContents('data/bookings');
+      if (!Array.isArray(files)) {
+        return [];
+      }
+      const bookings = [];
+      for (const file of files) {
+        if (file.type !== 'file' || !file.name.endsWith('.json')) continue;
+        const detail = await this.getFile(`data/bookings/${file.name}`);
+        try {
+          const json = JSON.parse(detail.decoded);
+          bookings.push({ ...json, path: `data/bookings/${file.name}`, sha: detail.sha });
+        } catch (error) {
+          console.warn('Invalid booking file', file.name, error);
+        }
+      }
+      return bookings.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+    } catch (error) {
+      if (error.status === 404) {
+        return [];
+      }
+      throw error;
+    }
+  }
+
+  async saveBooking(booking) {
+    if (!booking.path) {
+      throw new Error('booking-path-missing');
+    }
+    const payload = { ...booking };
+    delete payload.path;
+    delete payload.sha;
+    const content = JSON.stringify(payload, null, 2);
+    return this.updateFile({
+      path: booking.path,
+      message: `chore: update booking ${booking.id}`,
+      content,
+      sha: booking.sha,
+    });
+  }
+
+  async updateBookingStatus(booking, status) {
+    const detail = await this.getFile(booking.path);
+    const data = JSON.parse(detail.decoded);
+    data.status = status;
+    data.updatedAt = new Date().toISOString();
+    return this.updateFile({
+      path: booking.path,
+      message: `chore: set ${booking.id} to ${status}`,
+      content: JSON.stringify(data, null, 2),
+      sha: detail.sha,
+    });
+  }
+
+  async deleteBooking(booking) {
+    return this.deleteFile({
+      path: booking.path,
+      message: `chore: delete booking ${booking.id}`,
+      sha: booking.sha,
+    });
+  }
+
+  async listHouses() {
+    const detail = await this.getFile('data/houses.json');
+    const data = JSON.parse(detail.decoded);
+    return { houses: data, sha: detail.sha };
+  }
+
+  async updateHouses({ houses, sha }) {
+    return this.updateFile({
+      path: 'data/houses.json',
+      message: 'chore: update houses gallery',
+      content: JSON.stringify(houses, null, 2),
+      sha,
+    });
+  }
+
+  async uploadImage({ path, content, message }) {
+    return this.createFile({ path, content, message, encoded: true });
+  }
+
+  async removeImage({ path, sha }) {
+    return this.deleteFile({ path, sha, message: `chore: remove ${path}` });
+  }
+
+  async hasWriteAccess() {
+    const user = await this.ensureUser();
+    const data = await this.request(`/repos/${this.owner}/${this.repo}/collaborators/${user.login}/permission`);
+    return ['admin', 'write', 'maintain'].includes(data.permission);
+  }
+}
+
+export function buildAuthorizeUrl(clientId, redirectUri, state) {
+  const params = new URLSearchParams({
+    client_id: clientId,
+    allow_signup: 'false',
+    scope: 'repo',
+  });
+  if (state) {
+    params.set('state', state);
+  }
+  params.set('redirect_uri', redirectUri);
+  return `https://github.com/login/oauth/authorize?${params.toString()}`;
+}
+
+export async function exchangeCodeForToken(code) {
+  const config = await getConfig();
+  if (!config.oauthProxyUrl) {
+    throw new Error('missing-proxy');
+  }
+  const response = await fetch(config.oauthProxyUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code }),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    const error = new Error('oauth-failed');
+    error.responseText = text;
+    throw error;
+  }
+  return response.json();
+}
+
+export async function createClientFromConfig() {
+  const config = await getConfig();
+  const repoInfo = parseRepoFromConfig(config);
+  if (!repoInfo) {
+    throw new Error('repo-config-missing');
+  }
+  return new GitHubClient(repoInfo);
+}

--- a/src/services/i18n.js
+++ b/src/services/i18n.js
@@ -1,0 +1,68 @@
+import { dictionary, defaultLanguage, languages } from '../i18n.js';
+
+const STORAGE_KEY = 'citta-futura-lang';
+let currentLanguage = defaultLanguage;
+
+export function getCurrentLanguage() {
+  return currentLanguage;
+}
+
+export function t(key, lang = currentLanguage) {
+  const entry = dictionary[key];
+  if (!entry) {
+    console.warn(`[i18n] Missing key: ${key}`);
+    return key;
+  }
+  return entry[lang] ?? entry[defaultLanguage] ?? key;
+}
+
+export function setLanguage(lang, { persist = true } = {}) {
+  if (!languages.includes(lang)) {
+    console.warn(`[i18n] Unsupported language: ${lang}`);
+    return;
+  }
+  currentLanguage = lang;
+  if (persist && typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, lang);
+    } catch (error) {
+      console.warn('[i18n] Unable to persist language', error);
+    }
+  }
+  document.documentElement.lang = lang;
+  applyTranslations(lang);
+  document.dispatchEvent(new CustomEvent('language:changed', { detail: { lang } }));
+}
+
+export function initLanguage() {
+  let lang = defaultLanguage;
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored && languages.includes(stored)) {
+      lang = stored;
+    }
+  }
+  setLanguage(lang, { persist: false });
+}
+
+export function applyTranslations(lang = currentLanguage, root = document) {
+  root.querySelectorAll('[data-i18n]').forEach((el) => {
+    const key = el.dataset.i18n;
+    el.textContent = t(key, lang);
+  });
+
+  root.querySelectorAll('[data-i18n-html]').forEach((el) => {
+    const key = el.dataset.i18nHtml;
+    el.innerHTML = t(key, lang);
+  });
+
+  root.querySelectorAll('[data-i18n-attr]').forEach((el) => {
+    const attrPairs = el.dataset.i18nAttr.split(',');
+    attrPairs.forEach((pair) => {
+      const [attr, key] = pair.split(':').map((item) => item.trim());
+      if (attr && key) {
+        el.setAttribute(attr, t(key, lang));
+      }
+    });
+  });
+}

--- a/src/services/url.js
+++ b/src/services/url.js
@@ -1,0 +1,18 @@
+export function resolveSitePath(path = '') {
+  const base = (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.BASE_URL)
+    ? import.meta.env.BASE_URL
+    : '/';
+
+  const trimmedBase = base.endsWith('/') ? base.slice(0, -1) : base;
+  const trimmedPath = path.startsWith('/') ? path.slice(1) : path;
+
+  if (!trimmedBase || trimmedBase === '') {
+    return `/${trimmedPath}`;
+  }
+
+  if (trimmedBase === '.') {
+    return `./${trimmedPath}`;
+  }
+
+  return `${trimmedBase}/${trimmedPath}`;
+}

--- a/src/ui/intersection.js
+++ b/src/ui/intersection.js
@@ -1,0 +1,39 @@
+const fadeSelector = '[data-animate="fade"]';
+
+export function registerAnimations() {
+  if (typeof window === 'undefined' || !('IntersectionObserver' in window)) {
+    document.querySelectorAll(fadeSelector).forEach((el) => el.classList.remove('fade-enter'));
+    return;
+  }
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('fade-enter-active');
+          observer.unobserve(entry.target);
+        }
+      });
+    },
+    { threshold: 0.2 }
+  );
+
+  document.querySelectorAll(fadeSelector).forEach((el) => {
+    el.classList.add('fade-enter');
+    observer.observe(el);
+  });
+
+  const lazyImages = document.querySelectorAll('img.lazy-image');
+  lazyImages.forEach((img) => {
+    if (img.complete) {
+      img.dataset.loaded = 'true';
+    } else {
+      img.addEventListener('load', () => {
+        img.dataset.loaded = 'true';
+      });
+      img.addEventListener('error', () => {
+        img.dataset.loaded = 'true';
+      });
+    }
+  });
+}

--- a/src/ui/intersection.js
+++ b/src/ui/intersection.js
@@ -1,8 +1,41 @@
 const fadeSelector = '[data-animate="fade"]';
 
 export function registerAnimations() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const elements = document.querySelectorAll(fadeSelector);
+  const lazyImages = document.querySelectorAll('img.lazy-image');
+
+  const markImageLoaded = (img) => {
+    img.dataset.loaded = 'true';
+  };
+
+  lazyImages.forEach((img) => {
+    if (img.complete) {
+      markImageLoaded(img);
+    } else if (typeof window !== 'undefined') {
+      img.addEventListener('load', () => markImageLoaded(img));
+      img.addEventListener('error', () => markImageLoaded(img));
+    } else {
+      markImageLoaded(img);
+    }
+  });
+
   if (typeof window === 'undefined' || !('IntersectionObserver' in window)) {
-    document.querySelectorAll(fadeSelector).forEach((el) => el.classList.remove('fade-enter'));
+    elements.forEach((el) => el.classList.remove('fade-enter'));
+    return;
+  }
+
+  const prefersReducedMotion =
+    window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  if (prefersReducedMotion) {
+    elements.forEach((el) => {
+      el.classList.remove('fade-enter');
+      el.classList.remove('fade-enter-active');
+    });
     return;
   }
 
@@ -18,22 +51,8 @@ export function registerAnimations() {
     { threshold: 0.2 }
   );
 
-  document.querySelectorAll(fadeSelector).forEach((el) => {
+  elements.forEach((el) => {
     el.classList.add('fade-enter');
     observer.observe(el);
-  });
-
-  const lazyImages = document.querySelectorAll('img.lazy-image');
-  lazyImages.forEach((img) => {
-    if (img.complete) {
-      img.dataset.loaded = 'true';
-    } else {
-      img.addEventListener('load', () => {
-        img.dataset.loaded = 'true';
-      });
-      img.addEventListener('error', () => {
-        img.dataset.loaded = 'true';
-      });
-    }
   });
 }

--- a/src/ui/toast.js
+++ b/src/ui/toast.js
@@ -1,0 +1,17 @@
+import Alpine from 'alpinejs';
+
+export function registerToastStore() {
+  Alpine.store('toast', {
+    items: [],
+    show(message, type = 'info') {
+      const id = crypto.randomUUID();
+      this.items.push({ id, message, type });
+      setTimeout(() => {
+        this.items = this.items.filter((item) => item.id !== id);
+      }, 5000);
+    },
+    clear() {
+      this.items = [];
+    },
+  });
+}

--- a/staticman.yml
+++ b/staticman.yml
@@ -1,35 +1,34 @@
-comments:
-  bookings:
-    enabled: true
-    branch: main
-    path: "data/bookings"
-    filename: "{options.slug}.json"
-    format: json
-    moderation: true
-    commitMessage: "feat(booking): add {fields.id}"
-    transforms:
-      email: lower
-    allowedFields:
-      - id
-      - houseId
-      - name
-      - email
-      - phone
-      - checkin
-      - checkout
-      - people
-      - notes
-      - status
-      - createdAt
-      - source
-    requiredFields:
-      - houseId
-      - name
-      - email
-      - phone
-      - checkin
-      - checkout
-      - people
-    message:
-      success: "Booking received"
-      error: "Unable to save booking"
+bookings:
+  enabled: true
+  branch: main
+  path: "data/bookings"
+  filename: "{options.slug}.json"
+  format: json
+  moderation: true
+  commitMessage: "feat(booking): add {fields.id}"
+  transforms:
+    email: lower
+  allowedFields:
+    - id
+    - houseId
+    - name
+    - email
+    - phone
+    - checkin
+    - checkout
+    - people
+    - notes
+    - status
+    - createdAt
+    - source
+  requiredFields:
+    - houseId
+    - name
+    - email
+    - phone
+    - checkin
+    - checkout
+    - people
+  message:
+    success: "Booking received"
+    error: "Unable to save booking"

--- a/staticman.yml
+++ b/staticman.yml
@@ -1,0 +1,35 @@
+comments:
+  bookings:
+    enabled: true
+    branch: main
+    path: "data/bookings"
+    filename: "{options.slug}.json"
+    format: json
+    moderation: true
+    commitMessage: "feat(booking): add {fields.id}"
+    transforms:
+      email: lower
+    allowedFields:
+      - id
+      - houseId
+      - name
+      - email
+      - phone
+      - checkin
+      - checkout
+      - people
+      - notes
+      - status
+      - createdAt
+      - source
+    requiredFields:
+      - houseId
+      - name
+      - email
+      - phone
+      - checkin
+      - checkout
+      - people
+    message:
+      success: "Booking received"
+      error: "Unable to save booking"

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,27 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './index.html',
+    './houses.html',
+    './book.html',
+    './admin.html',
+    './privacy.html',
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        sand: '#F4E4C1',
+        terracotta: '#C26A4A',
+        sea: '#2A7F9E',
+        dusk: '#1E3A4C',
+        olive: '#3A5A40'
+      },
+      fontFamily: {
+        sans: ['"Work Sans"', 'system-ui', 'sans-serif'],
+        display: ['"Fraunces"', 'serif']
+      }
+    },
+  },
+  plugins: [require('@tailwindcss/forms')],
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+import path from 'node:path';
+
+export default defineConfig({
+  base: './',
+  root: '.',
+  build: {
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        houses: path.resolve(__dirname, 'houses.html'),
+        book: path.resolve(__dirname, 'book.html'),
+        admin: path.resolve(__dirname, 'admin.html'),
+        privacy: path.resolve(__dirname, 'privacy.html'),
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a shared helper so Alpine fetches and booking links honor the GitHub Pages base path
- switch page navigation and CTAs to relative URLs and relocate the runtime config under `public/.well-known`
- configure Vite with a `./` base so built assets resolve when the site is served from a subdirectory

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cafd23b3948326b414ca4a413b4d18